### PR TITLE
fix: nonetype module causes crash

### DIFF
--- a/src/creosote/parsers.py
+++ b/src/creosote/parsers.py
@@ -148,7 +148,7 @@ def get_module_info_from_code(path):
         if isinstance(node, ast.Import):
             module = []
         elif isinstance(node, ast.ImportFrom):
-            module = node.module.split(".")
+            module = node.module.split(".") if node.module else []
         else:
             continue
 


### PR DESCRIPTION
This addresses the bug found in https://github.com/fredrikaverpil/creosote/issues/114#issuecomment-1455670134