### PR TITLE
Handle editable requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .venv
 dist
+__pycache__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,5 +109,6 @@ python_version = "3.7"
 module = [
     "distlib.*",
     "dotty_dict.*",
+    "pip_requirements_parser.*"
 ]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "distlib>=0.3.4,<0.4",
     "dotty-dict>=1.3.1,<1.4",
     "loguru>=0.6.0,<0.7",
+    "pip-requirements-parser>=32.0.1,<33.1",
     "toml>=0.10.2,<0.11",
 ]
 

--- a/src/creosote/cli.py
+++ b/src/creosote/cli.py
@@ -35,7 +35,7 @@ def parse_args(args):
         dest="paths",
         default=glob.glob("src"),
         nargs="*",
-        help=("one or more paths to Python files"),
+        help="one or more paths to Python files",
     )
     parser.add_argument(
         "-v",

--- a/src/creosote/parsers.py
+++ b/src/creosote/parsers.py
@@ -62,7 +62,8 @@ class PackageReader:
 
     def requirements(self, deps_file: str):
         """Return dependencies from requirements.txt-format file."""
-        return sorted([dep.name for dep in RequirementsFile.from_file(deps_file).requirements])
+        deps = RequirementsFile.from_file(deps_file).requirements
+        return sorted([dep.name for dep in deps if dep.name is not None])
 
     @staticmethod
     def parse_dep_string(dep: str):

--- a/src/creosote/parsers.py
+++ b/src/creosote/parsers.py
@@ -59,7 +59,6 @@ class PackageReader:
 
         return sorted(deps)
 
-
     def requirements(self, deps_file: str):
         """Return dependencies from requirements.txt-format file."""
         deps = RequirementsFile.from_file(deps_file).requirements

--- a/src/creosote/parsers.py
+++ b/src/creosote/parsers.py
@@ -6,6 +6,7 @@ from functools import lru_cache
 import toml
 from dotty_dict import dotty
 from loguru import logger
+from pip_requirements_parser import RequirementsFile
 
 from creosote.models import Import, Package
 
@@ -58,19 +59,10 @@ class PackageReader:
 
         return sorted(deps)
 
+
     def requirements(self, deps_file: str):
         """Return dependencies from requirements.txt-format file."""
-        deps = []
-        with open(deps_file, "r") as infile:
-            contents = infile.readlines()
-
-        for line in contents:
-            if line.startswith("#") or line.startswith(" "):
-                continue
-            parsed_dep = self.parse_dep_string(line)
-            deps.append(parsed_dep)
-
-        return sorted(deps)
+        return sorted([dep.name for dep in RequirementsFile.from_file(deps_file).requirements])
 
     @staticmethod
     def parse_dep_string(dep: str):

--- a/src/creosote/resolvers.py
+++ b/src/creosote/resolvers.py
@@ -35,8 +35,8 @@ class DepsResolver:
 
     def top_level_names(self, package):
         package_name = package.name.replace("-", "_")
-        site_path = pathlib.Path(".")
-        glob_str = f"{self.venv}/**/{package_name}*.dist-info/top_level.txt"
+        site_path = pathlib.Path(self.venv)
+        glob_str = f"**/{package_name}*.dist-info/top_level.txt"
         top_levels = site_path.glob(glob_str)
         for top_level in top_levels:
             with open(top_level, "r") as infile:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,14 +23,16 @@ def with_poetry_packages(_stash_away_project_toml, capsys, request):
             ["poetry", "add", *request.param],
             stdout=subprocess.DEVNULL,
         )
-    yield
-    with capsys.disabled():
-        subprocess.run(
-            ["poetry", "remove", *request.param],
-            stdout=subprocess.DEVNULL,
-        )
-        pathlib.Path("poetry.lock").unlink()
-        Path(repo_root / "pyproject.toml").rename(deps_files / "pyproject.poetry.toml")
+    try:
+        yield
+    finally:
+        with capsys.disabled():
+            subprocess.run(
+                ["poetry", "remove", *request.param],
+                stdout=subprocess.DEVNULL,
+            )
+            pathlib.Path("poetry.lock").unlink()
+            Path(repo_root / "pyproject.toml").rename(deps_files / "pyproject.poetry.toml")
 
 
 @pytest.fixture()
@@ -44,13 +46,15 @@ def with_pyproject_pep621_packages(_stash_away_project_toml, capsys, request):
             ["pip", "install", *request.param],
             stdout=subprocess.DEVNULL,
         )
-    yield
-    with capsys.disabled():
-        subprocess.run(
-            ["pip", "uninstall", "-y", *request.param],
-            stdout=subprocess.DEVNULL,
-        )
-        Path(repo_root / "pyproject.toml").rename(deps_files / "pyproject.pep621.toml")
+    try:
+        yield
+    finally:
+        with capsys.disabled():
+            subprocess.run(
+                ["pip", "uninstall", "-y", *request.param],
+                stdout=subprocess.DEVNULL,
+            )
+            Path(repo_root / "pyproject.toml").rename(deps_files / "pyproject.pep621.toml")
 
 
 @pytest.fixture()
@@ -64,10 +68,12 @@ def with_requirements_txt_packages(_stash_away_project_toml, capsys, request):
             ["pip", "install", *request.param],
             stdout=subprocess.DEVNULL,
         )
-    yield
-    with capsys.disabled():
-        subprocess.run(
-            ["pip", "uninstall", "-y", *request.param],
-            stdout=subprocess.DEVNULL,
-        )
-        Path(repo_root / "requirements.txt").rename(deps_files / "requirements.txt")
+    try:
+        yield
+    finally:
+        with capsys.disabled():
+            subprocess.run(
+                ["pip", "uninstall", "-y", *request.param],
+                stdout=subprocess.DEVNULL,
+            )
+            Path(repo_root / "requirements.txt").rename(deps_files / "requirements.txt")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,9 @@ def with_poetry_packages(_stash_away_project_toml, capsys, request):
                 stdout=subprocess.DEVNULL,
             )
             pathlib.Path("poetry.lock").unlink()
-            Path(repo_root / "pyproject.toml").rename(deps_files / "pyproject.poetry.toml")
+            Path(repo_root / "pyproject.toml").rename(
+                deps_files / "pyproject.poetry.toml"
+            )
 
 
 @pytest.fixture()
@@ -54,7 +56,9 @@ def with_pyproject_pep621_packages(_stash_away_project_toml, capsys, request):
                 ["pip", "uninstall", "-y", *request.param],
                 stdout=subprocess.DEVNULL,
             )
-            Path(repo_root / "pyproject.toml").rename(deps_files / "pyproject.pep621.toml")
+            Path(repo_root / "pyproject.toml").rename(
+                deps_files / "pyproject.pep621.toml"
+            )
 
 
 @pytest.fixture()

--- a/tests/deps_files/requirements.txt
+++ b/tests/deps_files/requirements.txt
@@ -1,3 +1,6 @@
+
+-i https://pypi.org/simple
+-e git+https://github.com/psf/black.git@4a063a9#egg=black
 idna @ git+https://git@github.com/kjd/idna.git@master
 requests
 boto3>=1.26.0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,7 +39,7 @@ def test_pyproject_pep621(capsys):
     )
 
     captured = capsys.readouterr()
-    expected_log = "distlib\ndotty-dict\ntoml\n"
+    expected_log = "distlib\ndotty-dict\npip-requirements-parser\ntoml\n"
 
     assert captured.out == expected_log
 
@@ -79,6 +79,6 @@ def test_requirementstxt_directrefs(capsys, with_requirements_txt_packages):
     )
 
     captured = capsys.readouterr()
-    expected_log = "boto3\nidna\nrequests\n"
+    expected_log = "black\nboto3\nidna\nrequests\n"
 
     assert captured.out == expected_log


### PR DESCRIPTION
requirements.txt can contain lines which are not handled by the current parser. [pip-requirements-parser](https://pypi.org/project/pip-requirements-parser/) can handle rows like:

```
-i https://pypi.org/simple
-e git+https://github.com/psf/black.git@4a063a9#egg=black
```

I also updated the test fixtures to use a `try-yield-finally` pattern so that files get renamed back even when tests fail.

The change to `top_level_names` seemed to be necessary; I was getting an error like:

```
Traceback (most recent call last):
  File "/Users/elijah/.asdf/installs/python/3.9.15/bin/creosote", line 8, in <module>
    sys.exit(main())
  File "/Users/elijah/Development/creosote/src/creosote/cli.py", line 90, in main
    deps_resolver.resolve()
  File "/Users/elijah/Development/creosote/src/creosote/resolvers.py", line 109, in resolve
    self.populate_packages()
  File "/Users/elijah/Development/creosote/src/creosote/resolvers.py", line 86, in populate_packages
    self.top_level_names(package)
  File "/Users/elijah/Development/creosote/src/creosote/resolvers.py", line 41, in top_level_names
    for top_level in top_levels:
  File "/Users/elijah/.asdf/installs/python/3.9.15/lib/python3.9/pathlib.py", line 1175, in glob
    raise NotImplementedError("Non-relative patterns are unsupported")
```