### PR TITLE
fix: bad glob

### DIFF
--- a/src/creosote/models.py
+++ b/src/creosote/models.py
@@ -12,7 +12,7 @@ class Import:
 @dataclasses.dataclass
 class Package:
     name: str
-    top_level_names: Optional[List[str]] = None
+    top_level_import_names: Optional[List[str]] = None
     module_name: Optional[str] = None
     importable_as: Optional[str] = None
     associated_imports: List[Import] = dataclasses.field(default_factory=list)

--- a/src/creosote/parsers.py
+++ b/src/creosote/parsers.py
@@ -165,7 +165,7 @@ def get_modules_from_code(paths):
             resolved_paths.append(pathlib.Path(path).resolve())
 
     for resolved_path in resolved_paths:
-        logger.info(f"Parsing {resolved_path}")
+        logger.debug(f"Parsing {resolved_path}")
         for imp in get_module_info_from_code(resolved_path):
             imports.append(imp)
 

--- a/src/creosote/resolvers.py
+++ b/src/creosote/resolvers.py
@@ -125,11 +125,12 @@ class DepsResolver:
             self.map_package_to_module_via_distlib(package)
 
     def associate(self):
+        """Associate package name with import (module) name"""
         for package in self.packages:
             self.associate_imports_with_package(package, package.name)
             if package.top_level_import_names:
-                for t in package.top_level_import_names:
-                    self.associate_imports_with_package(package, t)
+                for import_name in package.top_level_import_names:
+                    self.associate_imports_with_package(package, import_name)
             if package.module_name:
                 # fallback to module name
                 self.associate_imports_with_package(package, package.module_name)

--- a/src/creosote/resolvers.py
+++ b/src/creosote/resolvers.py
@@ -35,13 +35,21 @@ class DepsResolver:
 
     def top_level_names(self, package):
         package_name = package.name.replace("-", "_")
+        logger.debug(f"Fetching the import name, based on package name: {package_name}")
         site_path = pathlib.Path(self.venv)
-        glob_str = f"**/{package_name}*.dist-info/top_level.txt"
-        top_levels = site_path.glob(glob_str)
+        glob_str = "**/*.dist-info/top_level.txt"
+        top_levels = site_path.glob(glob_str)  # TODO: not performant!
+
         for top_level in top_levels:
-            with open(top_level, "r") as infile:
-                lines = infile.readlines()
-            package.top_level_names = [line.strip() for line in lines]
+            if package_name.lower() in str(top_level).lower():  # TODO: not good enough
+                with open(top_level, "r") as infile:
+                    lines = infile.readlines()
+                package.top_level_names = [line.strip() for line in lines]
+                logger.debug(
+                    f"Mapped package name '{package_name}' to import name(s): "
+                    f"{','.join(package.top_level_names)}"
+                )
+                continue
 
     def package_to_module(self, package: Package):
         dp = database.DistributionPath(include_egg=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -64,6 +64,25 @@ def test_pyproject_pep621_directrefs(capsys, with_pyproject_pep621_packages):
     assert captured.out == expected_log
 
 
+@pytest.mark.parametrize("with_poetry_packages", [["gitpython"]], indirect=True)
+def test_pyproject_case_sensitive_top_level_filepaths(capsys, with_poetry_packages):
+    cli.main(
+        [
+            "-p",
+            "src",
+            "-f",
+            "porcelain",
+            "-s",
+            "tool.poetry.dependencies",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    expected_log = "gitpython\n"
+
+    assert captured.out == expected_log
+
+
 @pytest.mark.parametrize("with_requirements_txt_packages", [["idna"]], indirect=True)
 def test_requirementstxt_directrefs(capsys, with_requirements_txt_packages):
     cli.main(


### PR DESCRIPTION
This tries to fix the inability to find the package name of `gitpython`'s corresponding import name of `git`: https://github.com/fredrikaverpil/creosote/issues/123

The reason for the failure in #123 is that the `glob` is case sensitive.

With the changes in this PR, the issue with `gitpython`/`GitPython` mapping to `git` is fixed:

```bash
belay on  main is  v0.0.0 via  v3.11.2 (.venv)
❯ ../creosote/.venv/bin/creosote --venv .venv --paths belay --deps-file pyproject.toml --sections tool.poetry.dependencies
Parsing belay/webrepl.py
Parsing belay/device.py
Parsing belay/pyboard.py
Parsing belay/__init__.py
Parsing belay/hash.py
Parsing belay/inspect.py
Parsing belay/exceptions.py
Parsing belay/executers.py
Parsing belay/_minify.py
Parsing belay/typing.py
Parsing belay/helpers.py
Parsing belay/__main__.py
Parsing belay/project.py
Parsing belay/snippets/startup.py
Parsing belay/snippets/convenience_imports_micropython.py
Parsing belay/snippets/hf_viper.py
Parsing belay/snippets/ilistdir_circuitpython.py
Parsing belay/snippets/convenience_imports_circuitpython.py
Parsing belay/snippets/__init__.py
Parsing belay/snippets/sync_begin.py
Parsing belay/snippets/ilistdir_micropython.py
Parsing belay/snippets/emitter_check.py
Parsing belay/snippets/hf_native.py
Parsing belay/snippets/hf.py
Parsing belay/packagemanager/sync.py
Parsing belay/packagemanager/models.py
Parsing belay/packagemanager/__init__.py
Parsing belay/packagemanager/group.py
Parsing belay/packagemanager/downloaders/_github.py
Parsing belay/packagemanager/downloaders/__init__.py
Parsing belay/packagemanager/downloaders/common.py
Parsing belay/cli/update.py
Parsing belay/cli/sync.py
Parsing belay/cli/run.py
Parsing belay/cli/clean.py
Parsing belay/cli/terminal.py
Parsing belay/cli/exec.py
Parsing belay/cli/cache.py
Parsing belay/cli/__init__.py
Parsing belay/cli/common.py
Parsing belay/cli/new.py
Parsing belay/cli/install.py
Parsing belay/cli/identify.py
Parsing belay/cli/main.py
Parsing belay/cli/info.py
Parsing belay/cli/new_template/main.py
Parsing belay/cli/new_template/packagename/__init__.py
Parsing pyproject.toml for packages
Detected Poetry toml section in pyproject.toml
Found packages in pyproject.toml: aiohttp, autoregistry, fsspec, gitpython, pathspec, pydantic, pyserial, requests, tomli, typer, typing-extensions
Resolving package<->import name... (uses venv provided by --venv):
Unused packages found: aiohttp, typing-extensions
```