### PR TITLE
Open files for reading with utf-8 encoding

### DIFF
--- a/src/creosote/parsers.py
+++ b/src/creosote/parsers.py
@@ -33,7 +33,7 @@ class PackageReader:
 
     def pyproject(self, deps_file: str, sections: List[str]):
         """Return dependencies from pyproject.toml."""
-        with open(deps_file, "r") as infile:
+        with open(deps_file, "r", encoding="utf-8") as infile:
             contents = toml.loads(infile.read())
 
         dotty_contents: Dotty = dotty(contents)
@@ -141,7 +141,7 @@ def get_module_info_from_code(path):
     Credit:
         https://stackoverflow.com/a/9049549/2448495
     """
-    with open(path) as fh:
+    with open(path, encoding="utf-8") as fh:
         root = ast.parse(fh.read(), path)
 
     for node in ast.iter_child_nodes(root):  # or potentially ast.walk ?

--- a/src/creosote/resolvers.py
+++ b/src/creosote/resolvers.py
@@ -61,7 +61,7 @@ class DepsResolver:
             matches = self.top_level_package_pattern.findall(str(top_level_filepath))
             for top_level_package in matches:
                 if top_level_package.lower() == package_name.lower():
-                    with open(top_level_filepath, "r") as infile:
+                    with open(top_level_filepath, "r", encoding="utf-8") as infile:
                         lines = infile.readlines()
                     package.top_level_import_names = [line.strip() for line in lines]
                     import_names = ",".join(package.top_level_import_names)


### PR DESCRIPTION
## Why is the change needed?

- Any issue was reported in #124 where `open()` calls did not succeed.

## What was done in this PR?

- Add `encoding="utf-8"` to all `open()` calls.

## Are there any concerns, side-effects, additional notes?

- 🤔 I'm a little concerned this will affect some systems, and cause similar issues, but where `utf-8` was not expected. Technically, this could mean this is a backwards-compatibility breaking change...?

## Checklist, when applicable

- [ ] Added test(s)
- [ ] Updated README.md
- [ ] Is this a backwards-compatibility breaking change?
- [x] Resolves: #124 
