### PR TITLE
Natively support pre-commit: .pre-commit-hooks.yaml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: creosote
+  name: creosote
+  description: Identify unused dependencies and avoid a bloated virtual environment
+  entry: creosote
+  language: python
+  pass_filenames: false


### PR DESCRIPTION
Allows users to add to their `.pre-commit-config.yaml` file like:

```
  - repo: https://github.com/fredrikaverpil/creosote
    rev: v2.3.3
    hooks:
      - id: creosote
        args:
          - "--venv=.venv"
          - "--paths=MY_PROJECT_PATH"
          - "--deps-file=pyproject.toml"
          - "--sections=tool.poetry.dependencies"
```

We can add this to the readme, but it might be annoying to update the `rev` in the readme when tagging new releases.