### PR TITLE
Use $VIRTUAL_ENV and .venv as default --venv value

### DIFF
--- a/src/creosote/cli.py
+++ b/src/creosote/cli.py
@@ -1,11 +1,22 @@
 import argparse
 import glob
+import os
 import sys
+from pathlib import Path
 
 from loguru import logger
 
 from creosote import formatters, parsers, resolvers
 from creosote.__about__ import __version__
+
+
+def default_venv_argument():
+    activated_virtual_env = os.environ.get("VIRTUAL_ENV")
+    if activated_virtual_env:
+        return activated_virtual_env
+    elif Path(".venv").exists():
+        return ".venv"
+    return None
 
 
 def parse_args(args):
@@ -49,7 +60,7 @@ def parse_args(args):
         "-v",
         "--venv",
         dest="venv",
-        default=".venv",
+        default=default_venv_argument(),
         help="path to the virtual environment you want to scan",
     )
 

--- a/src/creosote/resolvers.py
+++ b/src/creosote/resolvers.py
@@ -121,7 +121,7 @@ class DepsResolver:
         imports found in the source code by the AST parser.
         """
         logger.debug("Attempting to find import names...")
-        venv_exists = Path(self.venv).exists()
+        venv_exists = bool(self.venv and Path(self.venv).exists())
         found_import_name = False
 
         if not venv_exists:


### PR DESCRIPTION
## Why is the change needed?

- #138 

## What was done in this PR?

- Default to `$VIRTUAL_ENV` before attempting to defaulting to `.venv`.

## Are there any concerns, side-effects, additional notes?

- A bit weird to have two defaults...

## Checklist, when applicable

- [ ] Added test(s)
- [ ] Updated README.md
- [x] Is this a backwards-compatibility breaking change?
- [ ] Resolves: #138

