### PR TITLE
Conform to mentioning dependencies (not packages)

### DIFF
--- a/src/creosote/formatters.py
+++ b/src/creosote/formatters.py
@@ -4,7 +4,7 @@ from typing import List
 from loguru import logger
 
 
-def configure_logger(verbose: bool, format_: str):
+def configure_logger(verbose: bool, format_: str) -> None:
     logger.remove()
 
     if format_ == "porcelain":
@@ -19,14 +19,14 @@ def configure_logger(verbose: bool, format_: str):
         )
 
 
-def print_results(unused_packages: List[str], format_: str) -> None:
-    if unused_packages:
+def print_results(unused_dependency_names: List[str], format_: str) -> None:
+    if unused_dependency_names:
         if format_ == "porcelain":
-            print("\n".join(unused_packages))
+            print("\n".join(unused_dependency_names))
         else:
             logger.error(
                 "Oh no, bloated venv! 🤢 🪣\n"
-                f"Unused packages found: {', '.join(unused_packages)}"
+                f"Unused dependencies found: {', '.join(unused_dependency_names)}"
             )
     else:
-        logger.info("No unused packages found! ✨")
+        logger.info("No unused dependencies found! ✨")

--- a/src/creosote/models.py
+++ b/src/creosote/models.py
@@ -3,16 +3,16 @@ from typing import List, Optional
 
 
 @dataclasses.dataclass
-class Import:
+class ImportInfo:
     module: List[str]
     name: List[str]
     alias: Optional[str] = None
 
 
 @dataclasses.dataclass
-class PackageInfo:
+class DependencyInfo:
     name: str  # as defined in the dependencies specification file
     top_level_import_names: Optional[List[str]] = None
     distlib_db_import_name: Optional[str] = None
-    canonicalized_package_name: Optional[str] = None
-    associated_imports: List[Import] = dataclasses.field(default_factory=list)
+    canonicalized_dep_name: Optional[str] = None
+    associated_imports: List[ImportInfo] = dataclasses.field(default_factory=list)

--- a/src/creosote/parsers.py
+++ b/src/creosote/parsers.py
@@ -153,7 +153,7 @@ class DependencyReader:
         return None
 
 
-def get_module_info_from_code(path) -> Generator[ImportInfo, None, None]:
+def get_module_info_from_python_file(path: str) -> Generator[ImportInfo, None, None]:
     """Get imports, based on given filepath.
 
     Credit:
@@ -191,7 +191,7 @@ def get_module_names_from_code(paths: List[str]) -> List[ImportInfo]:
 
     for resolved_path in resolved_paths:
         logger.debug(f"Parsing {resolved_path}")
-        for import_info in get_module_info_from_code(resolved_path):
+        for import_info in get_module_info_from_python_file(path=str(resolved_path)):
             imports.append(import_info)
 
     dupes_removed = []

--- a/src/creosote/parsers.py
+++ b/src/creosote/parsers.py
@@ -136,6 +136,7 @@ class DependencyReader:
         if match and match.groups():
             dep_name = match.groups()[0]
             return dep_name
+        return None
 
     @staticmethod
     def dependency_without_direct_reference(
@@ -149,6 +150,7 @@ class DependencyReader:
         if match and match.groups():
             dep_name = match.groups()[0]
             return dep_name
+        return None
 
 
 def get_module_info_from_code(path) -> Generator[ImportInfo, None, None]:
@@ -169,7 +171,11 @@ def get_module_info_from_code(path) -> Generator[ImportInfo, None, None]:
             continue
 
         for n in node.names:
-            yield ImportInfo(module, n.name.split("."), n.asname)
+            yield ImportInfo(
+                module=module,
+                name=n.name.split("."),
+                alias=n.asname,
+            )
 
 
 def get_module_names_from_code(paths):

--- a/src/creosote/resolvers.py
+++ b/src/creosote/resolvers.py
@@ -7,44 +7,44 @@ from typing import List
 from distlib import database
 from loguru import logger
 
-from creosote.models import Import, PackageInfo
+from creosote.models import DependencyInfo, ImportInfo
 
 
 class DepsResolver:
     def __init__(
         self,
-        imports: List[Import],
-        packages: List[str],
+        imports: List[ImportInfo],
+        dependency_names: List[str],
         venv: str,
     ):
         self.imports = imports
-        self.packages = [PackageInfo(name=package) for package in packages]
+        self.dependencies = [DependencyInfo(name=dep) for dep in dependency_names]
         self.venv = venv
 
-        self.map_package_to_import_via_top_level_txt_file
-        self.top_level_package_pattern = re.compile(
+        self.map_dep_to_import_via_top_level_txt_file
+        self.top_level_txt_pattern = re.compile(
             r"\/([\w]*).[\d\.]*.dist-info\/top_level.txt"
         )
 
-        self.unused_packages: List[PackageInfo] = []
+        self.unused_deps: List[DependencyInfo] = []
 
     @staticmethod
-    def canonicalize_module_name(module_name: str):
+    def canonicalize_module_name(module_name: str) -> str:
         return module_name.replace("-", "_").replace(".", "_").strip()
 
-    def is_importable(self, module_name: str):
+    def is_importable(self, module_name: str) -> bool:
         try:
             __import__(self.canonicalize_module_name(module_name))
             return True
         except ImportError:
             return False
 
-    def gather_top_level_filepaths(self):
+    def gather_top_level_filepaths(self) -> None:
         """Gathers all top_level.txt filepaths in the venv.
 
         Note:
             The path may contain case sensitive variations of the
-            package name, like e.g. GitPython for gitpython.
+            dependency name, like e.g. GitPython for gitpython.
         """
         logger.debug("Gathering all top_level.txt files in venv...")
         venv_path = pathlib.Path(self.venv)
@@ -54,46 +54,55 @@ class DepsResolver:
         for top_level_filepath in self.top_level_filepaths:
             logger.debug(f"Found {top_level_filepath}")
 
-    def map_package_to_import_via_top_level_txt_file(
-        self, package: PackageInfo
+    def map_dep_to_import_via_top_level_txt_file(
+        self, dep_info: DependencyInfo
     ) -> bool:
-        """Return True if import name was found in the top_level.txt."""
-        package_name = self.canonicalize_module_name(package.name)
+        """Map dependency to import via top_level.txt file.
+
+        Return True if import name was found in the top_level.txt,
+        otherwise return False.
+        """
+        dep_name = self.canonicalize_module_name(dep_info.name)
 
         for top_level_filepath in self.top_level_filepaths:
-            matches = self.top_level_package_pattern.findall(str(top_level_filepath))
-            for top_level_package in matches:
-                if top_level_package.lower() == package_name.lower():
+            matches = self.top_level_txt_pattern.findall(str(top_level_filepath))
+            for import_name_from_top_level in matches:
+                if import_name_from_top_level.lower() == dep_name.lower():
                     with open(top_level_filepath, "r", encoding="utf-8") as infile:
                         lines = infile.readlines()
-                    package.top_level_import_names = [line.strip() for line in lines]
-                    import_names = ",".join(package.top_level_import_names)
+                    dep_info.top_level_import_names = [line.strip() for line in lines]
+                    import_names = ",".join(dep_info.top_level_import_names)
                     logger.debug(
-                        f"[{package.name}] found import name "
+                        f"[{dep_info.name}] found import name "
                         f"via top_level.txt: {import_names} ⭐️"
                     )
                     return True
-        logger.debug(f"[{package.name}] did not find top_level.txt in venv")
+        logger.debug(f"[{dep_info.name}] did not find top_level.txt in venv")
         return False
 
-    def map_package_to_module_via_distlib(self, package: PackageInfo) -> bool:
+    def map_dep_to_module_via_distlib(self, dep_info: DependencyInfo) -> bool:
         """Fallback to distlib if we can't find the top_level.txt file.
+
+        Return True if import name was found in the distlib database,
+        otherwise return False.
 
         It seems this brings very little value right now, but I'll
         leave it in for now...
         """
         dp = database.DistributionPath(include_egg=True)
-        dist = dp.get_distribution(package.name)
+        dist = dp.get_distribution(dep_info.name)
 
         if dist is None:
             # raise ModuleNotFoundError
-            logger.debug(f"[{package.name}] did not find package in distlib.database")
+            logger.debug(
+                f"[{dep_info.name}] did not find dependency in distlib.database"
+            )
             return False
 
         # until we figure out something better... (not great)
-        module = self.canonicalize_module_name(package.name)
+        module_name = self.canonicalize_module_name(dep_info.name)
 
-        for filename, _, _ in dist.list_installed_files():
+        for filename, _, _ in dist.list_installed_files():  # TODO: #125
             if filename.endswith((".py")):
                 parts = os.path.splitext(filename)[0].split(os.sep)
                 if len(parts) == 1:  # windows sep varies with distribution type
@@ -101,23 +110,24 @@ class DepsResolver:
                 if parts[-1].startswith("_") and not parts[-1].startswith("__"):
                     continue  # ignore internals
                 elif filename.endswith(".py") and parts[-1] == "__init__":
-                    module = parts[-2]
+                    module_name = parts[-2]
                     break
 
         logger.debug(
-            f"[{package.name}] found import name " f"via distlib.database: {module} 🤞"
+            f"[{dep_info.name}] found import name "
+            f"via distlib.database: {module_name} 🤞"
         )
-        package.distlib_db_import_name = module
+        dep_info.distlib_db_import_name = module_name
         return True
 
     def gather_import_info(self):
-        """Populate Package object with import naming info.
+        """Populate DependencyInfo object with import naming info.
 
         There are three strategies from where the import name can be
         found:
             1. In the top_level.txt file in the venv.
             2. From the distlib database.
-            3. Guess the import name by canonicalizing the package name.
+            3. Guess the import name by canonicalizing the dep name.
 
         Later, these gathered import names will be compared against the
         imports found in the source code by the AST parser.
@@ -132,66 +142,69 @@ class DepsResolver:
                 "cannot resolve top-level names. This may lead to incorrect results."
             )
 
-        for package in self.packages:
+        for dep_info in self.dependencies:
             if venv_exists:
                 # best chance to get the import name
-                found_import_name = self.map_package_to_import_via_top_level_txt_file(
-                    package
+                found_import_name = self.map_dep_to_import_via_top_level_txt_file(
+                    dep_info
                 )
 
             if not found_import_name:
                 # fallback to distlib
-                found_import_name = self.map_package_to_module_via_distlib(package)
+                found_import_name = self.map_dep_to_module_via_distlib(dep_info)
 
             # this is really just guessing, but it's better than nothing
-            package.canonicalized_package_name = self.canonicalize_module_name(
-                package.name
+            dep_info.canonicalized_dep_name = self.canonicalize_module_name(
+                dep_info.name
             )
             if not found_import_name:
                 logger.debug(
-                    f"[{package.name}] relying on canonicalization "
-                    f"fallback: {package.canonicalized_package_name } 🤞"
+                    f"[{dep_info.name}] relying on canonicalization "
+                    f"fallback: {dep_info.canonicalized_dep_name } 🤞"
                 )
 
-    def associate_package_with_import(self, package: PackageInfo, import_name: str):
+    def associate_dep_with_import(self, dep_info: DependencyInfo, import_name: str):
         for imp in self.imports.copy():
             if not imp.module and import_name in imp.name:  # noqa: SIM114
                 # import <imp.name>
-                package.associated_imports.append(imp)
+                dep_info.associated_imports.append(imp)
             elif imp.name and import_name in imp.module:
                 # from <imp.name> import ...
-                package.associated_imports.append(imp)
+                dep_info.associated_imports.append(imp)
 
-    def associate_packages_with_imports(self):
-        """Associate package name with import (module) name.
+    def associate_dep_info_with_imports(self):
+        """Associate dependency name with import (module) name.
 
         The AST has found imports from the source code. This function
-        will now attempt to associate these imports with the Package
-        data, gathered from the venv, distlib, or canonicalization.
+        will now attempt to associate these imports with the
+        DependencyInfo data, gathered from the venv, distlib, or
+        canonicalization.
         """
-        for package in self.packages:
-            if package.top_level_import_names:
-                for top_level_import_name in package.top_level_import_names:
-                    self.associate_package_with_import(package, top_level_import_name)
-            elif package.distlib_db_import_name:
-                self.associate_package_with_import(
-                    package, package.distlib_db_import_name
+        for dep_info in self.dependencies:
+            if dep_info.top_level_import_names:
+                for top_level_import_name in dep_info.top_level_import_names:
+                    self.associate_dep_with_import(dep_info, top_level_import_name)
+            elif dep_info.distlib_db_import_name:
+                self.associate_dep_with_import(
+                    dep_info, dep_info.distlib_db_import_name
                 )
-            elif package.canonicalized_package_name:
-                self.associate_package_with_import(
-                    package, package.canonicalized_package_name
+            elif dep_info.canonicalized_dep_name:
+                self.associate_dep_with_import(
+                    dep_info, dep_info.canonicalized_dep_name
                 )
 
-    def get_unused_packages(self):
-        self.unused_packages = [
-            package for package in self.packages if not package.associated_imports
+    def get_unused_dependencies(self) -> None:
+        self.unused_deps = [
+            dep_info
+            for dep_info in self.dependencies
+            if not dep_info.associated_imports
         ]
 
-    def get_unused_package_names(self) -> List[str]:
-        return [package.name for package in self.unused_packages]
+    def get_unused_dependency_names(self) -> List[str]:
+        return [dep_info.name for dep_info in self.unused_deps]
 
     def resolve(self):
         self.gather_top_level_filepaths()
         self.gather_import_info()
-        self.associate_packages_with_imports()
-        self.get_unused_packages()
+        self.associate_dep_info_with_imports()
+        self.get_unused_dependencies()


### PR DESCRIPTION
## Why is the change needed?

- I've been very inconsistent in variable/function/class naming.

## What was done in this PR?

- Conformed terminology to talk about _dependencies_ (not e.g. _packages_) and various renaming.
- Added missing type definitions.

Bonus, while adding types:
- Noticed I was missing a return code when running `creosote --version`.
- Noticed I was adding `None` to the list to be returned by `load_pyproject_pep621`, so I added an if-statement and a warning log there.
- Noticed a hasattr(node, "names") was missing in `get_module_info_from_code`.

## Are there any concerns, side-effects, additional notes?

N/A

## Checklist, when applicable

- [ ] Added test(s)
- [ ] Updated README.md
- [ ] Is this a backwards-compatibility breaking change?
- [ ] Resolves: #issue-number-here

