### PR TITLE
Correct exit status when explicitly excluded deps are unused

### DIFF
--- a/src/creosote/cli.py
+++ b/src/creosote/cli.py
@@ -128,7 +128,9 @@ def main(args_=None):
     formatters.print_results(
         unused_dependency_names=unused_dependency_names, format_=args.format
     )
-    return 1 if unused_dependency_names else 0  # exit code
+    return (
+        1 if set(unused_dependency_names).difference(set(args.exclude_deps)) else 0
+    )  # exit code
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why is the change needed?

The exit status is incorrect when excluded deps are detected.

## What was done in this PR?


## Are there any concerns, side-effects, additional notes?


## Checklist, when applicable

- [x] Added test(s)
- [x] Updated README.md
- [x] Is this a backwards-compatibility breaking change?
- [ ] Resolves: #issue-number-here

