### PR TITLE
Excluded deps (and not installed) should not count towards unused dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,16 @@ The creosote tool will first scan the given python file(s) for all its imports. 
 
 See the `main` function in [`cli.py`](https://github.com/fredrikaverpil/creosote/blob/main/src/creosote/cli.py) for a terse overview of the logic.
 
+
+### 🌶️ Features
+
+Experimental or backwards compatibility breaking changes might be introduced as "features". Use the `--use-feature <FEATURE>` argument to enable.
+
+| Feature                           | Description                                                                                                                                                                                  |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `fail-excluded-and-not-installed` | When excluding a dependency from the scan (using `--exclude-deps`) and if the dependency is removed from the dependency specification file (e.g. `pyproject.toml`), return with exit code 1. |
+
+
 ### 😤 Known limitations
 
 - `importlib` imports are not detected by the AST parser (a great first contribution for anyone inclined 😄, reach out or start [here](https://github.com/fredrikaverpil/creosote/blob/72d4ce0a8a983725a704decce9083702aa2312cc/src/creosote/parsers.py#L138-L156)).
@@ -77,7 +87,7 @@ Note: Creosote supports identifying both unused production dependencies and deve
 
 | Tool/standard                                                                                                               |     Supported      | `--deps-file` value | Example `--sections` values                                                                                         |
 | --------------------------------------------------------------------------------------------------------------------------- | :----------------: | ------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| [PDM](https://pdm.fming.dev/latest/)                                                                                        | :white_check_mark: | `pyproject.toml`    | `project.dependencies`,<br>`project.optional-dependencies.<GROUP>`,<br>`tool.pdm.dev-dependencies`                  |   
+| [PDM](https://pdm.fming.dev/latest/)                                                                                        | :white_check_mark: | `pyproject.toml`    | `project.dependencies`,<br>`project.optional-dependencies.<GROUP>`,<br>`tool.pdm.dev-dependencies`                  |
 | [PEP-621](https://peps.python.org/pep-0621/)                                                                                | :white_check_mark: | `pyproject.toml`    | `project.dependencies`,<br>`project.optional-dependencies.<GROUP>`                                                  |
 | [Poetry](https://python-poetry.org/)                                                                                        | :white_check_mark: | `pyproject.toml`    | `tool.poetry.dependencies`,<br>`tool.poetry.dev-dependencies` (legacy),<br>`tool.poetry.group.<GROUP>.dependencies` |
 | [Pipenv](https://pipenv.pypa.io/en/latest/)                                                                                 | :white_check_mark: | `pyproject.toml`    | `packages`,<br>`dev-packages`                                                                                       |

--- a/src/creosote/cli.py
+++ b/src/creosote/cli.py
@@ -13,7 +13,6 @@ class Features(Enum):
     """Features that can be enabled via the --use-feature flag."""
 
     FAIL_EXCLUDED_AND_NOT_INSTALLED = "fail-excluded-and-not-installed"
-    PASS_EXCLUDED_AND_NOT_INSTALLED = "pass-excluded-and-not-installed"  # noqa: S105
 
 
 def parse_args(args):
@@ -148,9 +147,7 @@ def main(args_=None):
     # Return with exit code
     if unused_dependency_names:
         return 1
-    elif excluded_deps_and_not_installed:
-        if Features.PASS_EXCLUDED_AND_NOT_INSTALLED.value in args.features:
-            return 0
+    elif excluded_deps_and_not_installed:  # noqa: SIM102
         if Features.FAIL_EXCLUDED_AND_NOT_INSTALLED.value in args.features:
             return 1
     return 0

--- a/src/creosote/resolvers.py
+++ b/src/creosote/resolvers.py
@@ -16,12 +16,10 @@ class DepsResolver:
         imports: List[ImportInfo],
         dependency_names: List[str],
         venv: str,
-        excluded_deps_and_not_installed: List[str],
     ):
         self.imports = imports
         self.dependencies = [DependencyInfo(name=dep) for dep in dependency_names]
         self.venv = venv
-        self.excluded_deps_not_installed = excluded_deps_and_not_installed
 
         self.top_level_txt_pattern = re.compile(
             r"\/([\w]*).[\d\.]*.dist-info\/top_level.txt"
@@ -217,7 +215,6 @@ class DepsResolver:
 
         unused_dependency_names = sorted(
             [dep_info.name for dep_info in self.unused_deps]
-            + self.excluded_deps_not_installed
         )
 
         return unused_dependency_names

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -226,7 +226,7 @@ def test_detected_indirectly_used_but_not_imported_and_excluded(
 
 
 @pytest.mark.parametrize(
-    ["use_feature", "exit_code"],
+    ["use_feature", "expected_exit_code"],
     [
         ("", 0),  # no feature in use
         ("fail-excluded-and-not-installed", 1),
@@ -237,7 +237,7 @@ def test_unused_found_because_excluded_but_not_installed(
     mocker: MockerFixture,
     tmp_path: Path,
     use_feature: str,
-    exit_code: int,
+    expected_exit_code: int,
 ):
     """Excluded dependency is used but never imported by source code."""
     imports_from_code = [ImportInfo(module=[], name=["dotty_dict"])]
@@ -276,8 +276,8 @@ def test_unused_found_because_excluded_but_not_installed(
     if use_feature:
         args.extend(["--use-feature", use_feature])
 
-    exit_code_ = cli.main(args)
+    exit_code = cli.main(args)
     captured = capsys.readouterr()
 
     assert captured.out.splitlines() == expected_unused_packages
-    assert exit_code_ == exit_code
+    assert exit_code == expected_exit_code

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -228,8 +228,7 @@ def test_detected_indirectly_used_but_not_imported_and_excluded(
 @pytest.mark.parametrize(
     ["use_feature", "exit_code"],
     [
-        ("", 0),
-        ("pass-excluded-and-not-installed", 0),
+        ("", 0),  # no feature in use
         ("fail-excluded-and-not-installed", 1),
     ],
 )


### PR DESCRIPTION
## Why is the change needed?

- I need a way to provide experimental features.
- In #153, thanks to @sanmai-NL, I realized creosote is wrongly identifying excluded-and-not-installed deps as unused, along with an exit code of 1. This is a bug.

## What was done in this PR?

- Excluded-and-not-installed deps are no longer considered "unused". If a dependency is found to be excluded (and not installed), a warning will still be shown but the error code will be 0.
- Add features "facility"  along with new argument `--use-feature`. This is btw how the other arguments should've been set up... something to keep in mind for v3.0.0, although a rather big change that will break things for a lot of users...
- Add features for passing/failing the check whether excluded-and-not-installed deps are found. It's likely that I can remove the one for passing, as this is now the default.

## Are there any concerns, side-effects, additional notes?

- Even if the previous behavior is considered a bug, I did actually originally intend to use exit code 1 for when excluded-and-not-installed dependencies were detected. However, it's possible that this is a bad design decision and that it's better to provide an argument (`--use-feature fail-excluded-and-not-installed`) if you want this behavior. I've therefore made the exit code 0 in this case by default.

## Checklist, when applicable

- [ ] Added test(s)
- [ ] Updated README.md
- [ ] Is this a backwards-compatibility breaking change?
- [ ] Resolves: #issue-number-here

