### PR TITLE
Add feature for new arguments specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ Yes, you can specify a list of sections after the `--sections` argument. It all 
 $ creosote --sections project.dependencies project.optional-dependencies.lint project.optional-dependencies.test
 ```
 
+### Can I specify multiple virtual environment locations?
+
+Yes, you can specify the `--venv` parameter multiple times, such as `--venv .venv --venv other-venv`. You can also point `--venv` to any site-packages folder.
+
 ### Can I exclude dependencies from the scan?
 
 Yes, you can use the `--exclude-deps` argument to specify one or more dependencies you do not wish to get warnings for.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ See the `main` function in [`cli.py`](https://github.com/fredrikaverpil/creosote
 
 These optional features enable new/experimental functionality, that may be backward incompatible and may be removed at any time. Use at your own risk!
 
-
 | Feature                           | Description                                                                                                                                                                                                                                                                                                                                                                          |
 | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `fail-excluded-and-not-installed` | When excluding a dependency from the scan (using `--exclude-deps`) and if the dependency is removed from the dependency specification file (e.g. `pyproject.toml`), return with exit code 1.                                                                                                                                                                                         |

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ See the `main` function in [`cli.py`](https://github.com/fredrikaverpil/creosote
 
 ### 🌶️ Features
 
+These optional features enable new/experimental functionality, that may be backward incompatible and may be removed at any time. Use at your own risk!
+
 
 | Feature                           | Description                                                                                                                                                                                                                                                                                                                                                                          |
 | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |

--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ See the `main` function in [`cli.py`](https://github.com/fredrikaverpil/creosote
 ### 🌶️ Features
 
 
-| Feature                           | Description                                                                                                                                                                                  |
-| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `fail-excluded-and-not-installed` | When excluding a dependency from the scan (using `--exclude-deps`) and if the dependency is removed from the dependency specification file (e.g. `pyproject.toml`), return with exit code 1. |
-
+| Feature                           | Description                                                                                                                                                                                                                                                                                                                                                                          |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `fail-excluded-and-not-installed` | When excluding a dependency from the scan (using `--exclude-deps`) and if the dependency is removed from the dependency specification file (e.g. `pyproject.toml`), return with exit code 1.                                                                                                                                                                                         |
+| `v3-args`                         | Use the new arguments, which will be used in creosote version 3.0.0. In version 2.x, the argument is specified once and then space-separated values, like `-p <path1> <path2>`. This will change in version 3.0.0, where you will have to define the argument for each value, like `-p <path1> -p <path2>`. I believe this is more common and caters better for different use cases. |
 
 ### 😤 Known limitations
 

--- a/src/creosote/cli.py
+++ b/src/creosote/cli.py
@@ -85,7 +85,7 @@ def parse_args(args):
             metavar="PATH",
             action=CustomAppendAction,
             default=["src"],
-            help="paths(s) to Python source code to scan for imports",
+            help="path(s) to Python source code to scan for imports",
         )
         parser.add_argument(
             "-s",
@@ -102,7 +102,7 @@ def parse_args(args):
             metavar="DEPENDENCY",
             action="append",
             default=[],
-            help="dependencies to exclude from the scan",
+            help="dependency(ies) to exclude from the scan",
         )
     else:
         # v2.x behavior
@@ -149,7 +149,7 @@ def parse_args(args):
         metavar="PATH",
         action=CustomAppendAction,
         default=[".venv"],
-        help="path to the virtual environment to scan",
+        help="path(s) to the virtual environment to scan",
     )
     parser.add_argument(
         "--use-feature",

--- a/src/creosote/cli.py
+++ b/src/creosote/cli.py
@@ -132,8 +132,6 @@ def parse_args(args):
             help="dependencies to exclude from the scan",
         )
 
-    # TODO: Add support for supplying a list of deps files, which
-    # are coupled with the section(s) to read...?
     parser.add_argument(
         "-d",
         "--deps-file",

--- a/src/creosote/cli.py
+++ b/src/creosote/cli.py
@@ -13,6 +13,7 @@ class Features(Enum):
     """Features that can be enabled via the --use-feature flag."""
 
     FAIL_EXCLUDED_AND_NOT_INSTALLED = "fail-excluded-and-not-installed"
+    ARGS_CAN_BE_SPECIFIED_MULTIPLE_TIMES = "v3-args"
 
 
 class CustomAppendAction(argparse.Action):
@@ -74,23 +75,65 @@ def parse_args(args):
         choices=["default", "porcelain"],
         help="output format",
     )
-    parser.add_argument(
-        "-p",
-        "--paths",
-        dest="paths",
-        default=glob.glob("src"),
-        nargs="*",
-        help="paths(s) to Python source code to scan for imports",
-    )
-    parser.add_argument(
-        "-v",
-        "--venv",
-        dest="venvs",
-        metavar="PATH",
-        action=CustomAppendAction,
-        default=[".venv"],
-        help="path to the virtual environment to scan for dependencies",
-    )
+
+    if Features.ARGS_CAN_BE_SPECIFIED_MULTIPLE_TIMES.value in sys.argv:
+        # v3.0 behavior
+        parser.add_argument(
+            "-p",
+            "--path",
+            dest="paths",
+            metavar="PATH",
+            action=CustomAppendAction,
+            default=["src"],
+            help="paths(s) to Python source code to scan for imports",
+        )
+        parser.add_argument(
+            "-s",
+            "--section",
+            dest="sections",
+            metavar="TOML_SECTION",
+            action=CustomAppendAction,
+            default=["project.dependencies"],
+            help="pyproject.toml section(s) to scan for dependencies",
+        )
+        parser.add_argument(
+            "--exclude-dep",
+            dest="exclude_deps",
+            metavar="DEPENDENCY",
+            action="append",
+            default=[],
+            help="dependencies to exclude from the scan",
+        )
+    else:
+        # v2.x behavior
+        parser.add_argument(
+            "-p",
+            "--paths",
+            dest="paths",
+            default=glob.glob("src"),
+            nargs="*",
+            help="paths(s) to Python source code to scan for imports",
+        )
+        parser.add_argument(
+            "-s",
+            "--sections",
+            dest="sections",
+            metavar="TOML_SECTION",
+            nargs="*",
+            default=["project.dependencies"],
+            help="pyproject.toml section(s) to scan for dependencies",
+        )
+        parser.add_argument(
+            "--exclude-deps",
+            dest="exclude_deps",
+            metavar="DEPENDENCY",
+            nargs="*",
+            default=[],
+            help="dependencies to exclude from the scan",
+        )
+
+    # TODO: Add support for supplying a list of deps files, which
+    # are coupled with the section(s) to read...?
     parser.add_argument(
         "-d",
         "--deps-file",
@@ -100,21 +143,13 @@ def parse_args(args):
         help="path to the pyproject.toml or requirements[.txt|.in] file",
     )
     parser.add_argument(
-        "-s",
-        "--sections",
-        dest="sections",
-        metavar="SECTION",
-        nargs="*",
-        default=["project.dependencies"],
-        help="pyproject.toml section(s) to scan for dependencies",
-    )
-    parser.add_argument(
-        "--exclude-deps",
-        dest="exclude_deps",
-        metavar="DEPENDENCY",
-        nargs="*",
-        default=[],
-        help="dependencies to exclude from the scan",
+        "-v",
+        "--venv",
+        dest="venvs",
+        metavar="PATH",
+        action=CustomAppendAction,
+        default=[".venv"],
+        help="path to the virtual environment to scan",
     )
     parser.add_argument(
         "--use-feature",

--- a/src/creosote/parsers.py
+++ b/src/creosote/parsers.py
@@ -217,13 +217,18 @@ def get_installed_dependency_names(venv: str) -> List[str]:
 
 
 def get_excluded_deps_which_are_not_installed(
-    excluded_deps: List[str], venv: str
+    excluded_deps: List[str], venvs: List[str]
 ) -> List[str]:
     dependency_names = []
-    if excluded_deps:
-        for excluded_dep_name in excluded_deps:
+    if not excluded_deps:
+        return dependency_names
+
+    for excluded_dep_name in excluded_deps:
+        for venv in venvs:
             if excluded_dep_name not in get_installed_dependency_names(venv):
                 dependency_names.append(excluded_dep_name)
+
+    dependency_names = list(set(dependency_names))
 
     if dependency_names:
         logger.warning(

--- a/src/creosote/parsers.py
+++ b/src/creosote/parsers.py
@@ -219,7 +219,7 @@ def get_installed_dependency_names(venv: str) -> List[str]:
 def get_excluded_deps_which_are_not_installed(
     excluded_deps: List[str], venvs: List[str]
 ) -> List[str]:
-    dependency_names = []
+    dependency_names: List[str] = []
     if not excluded_deps:
         return dependency_names
 

--- a/src/creosote/resolvers.py
+++ b/src/creosote/resolvers.py
@@ -122,12 +122,14 @@ class DepsResolver:
                     found_module_name = parts[-2]
                     break
 
-        logger.debug(
-            f"[{dep_info.name}] found import name "
-            f"via distlib.database: {found_module_name} 🤞"
-        )
-        dep_info.distlib_db_import_name = found_module_name
-        return True
+        if found_module_name:
+            logger.debug(
+                f"[{dep_info.name}] found import name "
+                f"via distlib.database: {found_module_name} 🤞"
+            )
+            dep_info.distlib_db_import_name = found_module_name
+            return True
+        return False
 
     def map_dep_to_canonical_name(self, dep_info: DependencyInfo) -> str:
         return self.canonicalize_module_name(dep_info.name)

--- a/src/creosote/resolvers.py
+++ b/src/creosote/resolvers.py
@@ -52,7 +52,7 @@ class DepsResolver:
         venv_exists = Path(venv).exists()
         if not venv_exists:
             logger.warning(
-                f"Virtual environment '{self.venvs}' does not exist, "
+                f"Virtual environment(s) '{', '.join(self.venvs)}' does not exist, "
                 "cannot resolve top-level names. This may lead to incorrect results."
             )
 


### PR DESCRIPTION
## Why is the change needed?

Currently, a somewhat weird way of suppliying multiple values to the same argument is being used.

```bash
creosote -p somefile1.py somefile2.py
```

## What was done in this PR?

- Use the more common (?) pattern of allowing for repeated definitions of the same argument (requires `v3-args` feature, since this would be backwards compatibility breaking behavior). Example:

```bash
creosote --use-feature v3-args  -p somefile1.py -p somefile2.py
```

- Make it possible to specify multiple virtual environments using multiple `--venv` arguments.


## Are there any concerns, side-effects, additional notes?

None.


## Checklist, when applicable

- [ ] Added test(s)
- [ ] Updated README.md
- [ ] Is this a backwards-compatibility breaking change?
- [ ] Resolves: #issue-number-here

