### PR TITLE
Add trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
         run: "pip wheel --no-deps --use-pep517 --wheel-dir=dist ."
 
       - name: save artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: wheel
           path: dist
@@ -35,7 +35,7 @@ jobs:
       id-token: write
     steps:
       - name: retrieve artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: wheel
           path: dist

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+
+      - name: build package
+        run: "pip wheel --no-deps --use-pep517 --wheel-dir=dist ."
+
+      - name: save artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: wheel
+          path: dist
+
   pypi:
+    needs: build
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -18,15 +34,12 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        id: cpython_setup
+      - name: retrieve artifact
+        uses: actions/download-artifact@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          name: wheel
+          path: dist
 
-      - name: Build package
-        run: pip wheel --no-deps --use-pep517 --wheel-dir=dist .
-
-      - name: Publish package
+      - name: publish wheel
         if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,11 @@ concurrency:
 jobs:
   pypi:
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/creosote
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -25,5 +30,3 @@ jobs:
       - name: Publish package
         if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Why is the change needed?

Use trusted publishing: https://github.com/pypa/gh-action-pypi-publish

## What was done in this PR?

Update the GHA workflow.

## Are there any concerns, side-effects, additional notes?

N/A
