### PR TITLE
fix: do not assume site-packages folder name

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The intent is to run Creosote in CI (or with [pre-commit](https://pre-commit.com
 
 | Tool/standard                                                                                                               | Supported | `--deps-file` value | Example `--sections` values                                                                                         |
 | --------------------------------------------------------------------------------------------------------------------------- | :-------: | ------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| [PDM](https://pdm.fming.dev/latest/)                                                                                        |     ✅     | `pyproject.toml`    | `project.dependencies`,<br>`project.optional-dependencies.<GROUP>`,<br>`tool.pdm.dev-dependencies`                  |
+| [PDM](https://pdm.fming.dev/latest/) and [https://peps.python.org/pep-0582/](PEP-582)                                                                                        |     ✅     | `pyproject.toml`    | `project.dependencies`,<br>`project.optional-dependencies.<GROUP>`,<br>`tool.pdm.dev-dependencies`                  |
 | [Pipenv](https://pipenv.pypa.io/en/latest/)                                                                                 |     ✅     | `pyproject.toml`    | `packages`,<br>`dev-packages`                                                                                       |
 | [Poetry](https://python-poetry.org/)                                                                                        |     ✅     | `pyproject.toml`    | `tool.poetry.dependencies`,<br>`tool.poetry.dev-dependencies` (legacy),<br>`tool.poetry.group.<GROUP>.dependencies` |
 | Legacy Setuptools (`setup.py`)                                                                                              |     ❌     |                     |                                                                                                                     |
@@ -88,6 +88,14 @@ The intent is to run Creosote in CI (or with [pre-commit](https://pre-commit.com
 #### 📔 Notes on [PEP-508](https://peps.python.org/pep-0508) (`requirements.txt`)
 
 When using `requirements.txt` files to specify dependencies, there is no way to tell which part of `requirements.txt` specifies production vs developer dependencies. Therefore, you have to break your `requirements.txt` file into e.g. `requirements-prod.txt` and `requirements-dev.txt` and use any of them as input. When using [pip-tools](https://pip-tools.readthedocs.io/en/latest/), you likely want to point Creosote to scan your `*.in` file(s).
+
+#### 📓 Notes on [PEP-582](https://peps.python.org/pep-0582/) (`__pypackages__`)
+
+Creosote supports the `__pypackages__` folder, although PEP-582 was rejected. There is no reason to remove support for this today, but in case supporting this becomes cumbersome in the future, supporting PEP-582 might be dropped.
+
+```bash
+creosote --venv __pypackages__
+```
 
 ### Can I specify multiple toml sections?
 

--- a/src/creosote/parsers.py
+++ b/src/creosote/parsers.py
@@ -209,9 +209,8 @@ def get_module_names_from_code(paths: List[str]) -> List[ImportInfo]:
 
 
 def get_installed_dependency_names(venv: str) -> List[str]:
-    site_packages = Path(venv).glob("**/site-packages").__next__()
     dep_names = []
-    for path in site_packages.glob("**/*.dist-info"):
+    for path in Path(venv).glob("**/*.dist-info"):
         dep_names.append(path.name.split("-")[0])
     return dep_names
 


### PR DESCRIPTION
## Why is the change needed?

Currently, users of PEP-582 who wish to use creosote and point it to the `__pypackages__` folder instead of a venv cannot do this currently.

## What was done in this PR?

Update the regexp which used to assume a "site-packages" folder.

## Are there any concerns, side-effects, additional notes?

- Could be a bit slower, but likely not noticeable...
- Closes #169 

## Checklist, when applicable

- [ ] Added test(s)
- [ ] Updated README.md
- [ ] Is this a backwards-compatibility breaking change?
- [ ] Resolves: #issue-number-here

