### PR TITLE
Fix pipenv/Pipfile support

### DIFF
--- a/tests/deps_files/Pipfile
+++ b/tests/deps_files/Pipfile
@@ -1,0 +1,15 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+dotty-dict = ">=1.3.1,<1.4"
+loguru = ">=0.6.0,<0.7"
+toml = ">=0.10.2,<0.11"
+
+[dev-packages]
+pytest = "*"
+
+[requires]
+python_version = "3.11"

--- a/tests/fixtures/fast.py
+++ b/tests/fixtures/fast.py
@@ -27,7 +27,7 @@ def mock_dependencies_from_pyproject_toml(mocker: MockerFixture):
     def _(dependency_names: List[str]):
         # TODO: mock deeper down than this
         return mocker.patch(
-            "creosote.parsers.DependencyReader.load_pyproject",
+            "creosote.parsers.DependencyReader.read_toml",
             return_value=dependency_names,
         )
 

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,6 +1,25 @@
+from typing import List
+
 import pytest
 
 from creosote.parsers import DependencyReader
+
+
+@pytest.mark.parametrize(
+    ["sections", "expected_dependencies"],
+    [
+        (["packages"], ["dotty-dict", "loguru", "toml"]),
+        (["dev-packages"], ["pytest"]),
+    ],
+)
+def test_read_toml_pipfile(sections: List[str], expected_dependencies: List[str]):
+    reader = DependencyReader(
+        deps_file="tests/deps_files/Pipfile",
+        sections=sections,
+        exclude_deps=[],
+    )
+    dependencies = reader.read()
+    assert dependencies == expected_dependencies
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Why is the change needed?

It appears there's a bug when using pipenv / `Pipfile`: #173 


## What was done in this PR?

- Read Pipfile properly.

## Are there any concerns, side-effects, additional notes?


## Checklist, when applicable

- [ ] Added test(s)
- [ ] Updated README.md
- [ ] Is this a backwards-compatibility breaking change?
- [ ] Resolves: #issue-number-here

