### PR TITLE
Handle pep621 dependencies when defined as dict

### DIFF
--- a/src/creosote/parsers.py
+++ b/src/creosote/parsers.py
@@ -46,7 +46,6 @@ class DependencyReader:
             for dep_name in self.read_requirements(self.deps_file):
                 if dep_name not in deps_to_exclude:
                     dep_names.append(dep_name)
-
         else:
             raise NotImplementedError(
                 f"Dependency specs file {self.deps_file} is not supported."
@@ -58,35 +57,32 @@ class DependencyReader:
 
         return dep_names
 
-    def get_deps_from_pep621_toml(self, section_contents: List[str]) -> List[str]:
+    def get_deps_from_pep621_toml(
+        self, section_contents: Union[List[str], Dict[str, List[str]]]
+    ) -> List[str]:
         """Get dependency names from toml file using the PEP621 spec.
 
         The dependency strings are expected to follow PEP508.
         """
 
-        section_deps = []
-
+        dep_strings = []
         if isinstance(section_contents, list):
             for dep_string in section_contents:
-                parsed_dep = self.parse_dep_string(dep_string)
-                if parsed_dep:
-                    section_deps.append(parsed_dep)
-                else:
-                    logger.warning(f"Could not parse dependency string: {dep_string}")
-
+                dep_strings.append(dep_string)
         elif isinstance(section_contents, dict):
-            for group_name in section_contents:
-                for dep_string in section_contents[group_name]:
-                    parsed_dep = self.parse_dep_string(dep_string)
-                    if parsed_dep:
-                        section_deps.append(parsed_dep)
-                    else:
-                        logger.warning(
-                            f"Could not parse dependency string: {dep_string}"
-                        )
-
+            for _, dep_string_list in section_contents.items():
+                for dep_string in dep_string_list:
+                    dep_strings.append(dep_string)
         else:
             raise TypeError("Unexpected dependency format, list expected.")
+
+        section_deps = []
+        for dep_string in dep_strings:
+            parsed_dep = self.parse_dep_string(dep_string)
+            if parsed_dep:
+                section_deps.append(parsed_dep)
+            else:
+                logger.warning(f"Could not parse dependency string: {dep_string}")
 
         return section_deps
 

--- a/tests/deps_files/pyproject.pep621.toml
+++ b/tests/deps_files/pyproject.pep621.toml
@@ -7,28 +7,17 @@ license = "MIT"
 keywords = []
 authors = []
 dependencies = [
-    "dotty-dict>=1.3.1,<1.4",
-    "loguru>=0.6.0,<0.7",
-    "toml>=0.10.2,<0.11",
+  "dotty-dict>=1.3.1,<1.4",
+  "loguru>=0.6.0,<0.7",
+  "toml>=0.10.2,<0.11",
 ]
 
 [project.optional-dependencies]
 # PEP-440
-directrefs =[
+directrefs = [
   "typing_extensions @ git+https://git@github.com/python/typing_extensions.git@main",
 ]
-lint = [
-  "black",
-  "ruff",
-]
-types = [
-  "mypy",
-  "loguru-mypy",
-  "types-toml",
-]
-test = [
-    "pytest"
-]
-dev = [
-    "creosote[lint,types,test]",
-]
+lint = ["black", "ruff"]
+types = ["mypy", "loguru-mypy", "types-toml"]
+test = ["pytest"]
+dev = ["creosote[lint,types,test]"]

--- a/tests/deps_files/pyproject.poetry.toml
+++ b/tests/deps_files/pyproject.poetry.toml
@@ -24,3 +24,4 @@ types-toml = "*"
 
 [tool.poetry.group.directrefs.dependencies]
 typing_extensions = { git = "https://github.com/python/typing_extensions.git", branch = "main" }
+

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -8,6 +8,65 @@ from creosote.parsers import DependencyReader
 @pytest.mark.parametrize(
     ["sections", "expected_dependencies"],
     [
+        (
+            ["project.dependencies"],
+            ["dotty-dict", "loguru", "toml"],
+        ),
+        (
+            ["project.optional-dependencies"],
+            [
+                "black",
+                "creosote",
+                "loguru-mypy",
+                "mypy",
+                "pytest",
+                "ruff",
+                "types-toml",
+                "typing_extensions",
+            ],
+        ),
+    ],
+)
+def test_read_toml_pep621(sections: List[str], expected_dependencies: List[str]):
+    reader = DependencyReader(
+        deps_file="tests/deps_files/pyproject.pep621.toml",
+        sections=sections,
+        exclude_deps=[],
+    )
+    dependencies = reader.read()
+    assert dependencies == expected_dependencies
+
+
+@pytest.mark.parametrize(
+    ["sections", "expected_dependencies"],
+    [
+        (
+            ["tool.poetry.dependencies"],
+            ["dotty-dict", "loguru", "toml"],
+        ),
+        (
+            ["tool.poetry.group.dev.dependencies"],
+            ["black", "loguru-mypy", "mypy", "pytest", "ruff", "types-toml"],
+        ),
+        (
+            ["tool.poetry.group.directrefs.dependencies"],
+            ["typing_extensions"],
+        ),
+    ],
+)
+def test_read_toml_poetry(sections: List[str], expected_dependencies: List[str]):
+    reader = DependencyReader(
+        deps_file="tests/deps_files/pyproject.poetry.toml",
+        sections=sections,
+        exclude_deps=[],
+    )
+    dependencies = reader.read()
+    assert dependencies == expected_dependencies
+
+
+@pytest.mark.parametrize(
+    ["sections", "expected_dependencies"],
+    [
         (["packages"], ["dotty-dict", "loguru", "toml"]),
         (["dev-packages"], ["pytest"]),
     ],


### PR DESCRIPTION
## Why is the change needed?

When adding tests, I noticed that e.g. `project.optional-dependencies` are not handled correctly, if provided.

## What was done in this PR?

Add different parsing based on whether value of given toml section is of type `list` vs `dict`.

## Are there any concerns, side-effects, additional notes?

None.

## Checklist, when applicable

- [x] Added test(s)
- [ ] Updated README.md
- [ ] Is this a backwards-compatibility breaking change?
- [ ] Resolves: #issue-number-here

