### PR TITLE
chore: pin ruff to avoid CI breakage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ path = "src/creosote/__about__.py"
 
 [project.optional-dependencies]
 # PEP-440
-lint = ["black", "ruff"]
+lint = ["black", "ruff==0.0.290"]
 types = ["mypy", "loguru-mypy", "types-toml"]
 test = ["pytest", "pytest-mock", "coverage"]
 dev = ["creosote[lint,types,test]"]

--- a/src/creosote/resolvers.py
+++ b/src/creosote/resolvers.py
@@ -166,7 +166,7 @@ class DepsResolver:
 
     def associate_dep_with_import(self, dep_info: DependencyInfo, import_name: str):
         for imp in self.imports.copy():
-            if not imp.module and import_name in imp.name:  # noqa: SIM114
+            if not imp.module and import_name in imp.name:
                 # import <imp.name>
                 dep_info.associated_imports.append(imp)
 

--- a/tests/fixtures/manual.py
+++ b/tests/fixtures/manual.py
@@ -24,6 +24,7 @@ def with_poetry_packages(_stash_away_project_toml, capsys, request):
         subprocess.run(
             ["poetry", "add", *request.param],  # noqa: S603, S607
             stdout=subprocess.DEVNULL,
+            check=True,
         )
     try:
         yield
@@ -32,6 +33,7 @@ def with_poetry_packages(_stash_away_project_toml, capsys, request):
             subprocess.run(
                 ["poetry", "remove", *request.param],  # noqa: S603, S607
                 stdout=subprocess.DEVNULL,
+                check=True,
             )
             pathlib.Path("poetry.lock").unlink()
             Path(repo_root / "pyproject.toml").rename(
@@ -49,6 +51,7 @@ def with_pyproject_pep621_packages(_stash_away_project_toml, capsys, request):
         subprocess.run(
             ["pip", "install", *request.param],  # noqa: S603, S607
             stdout=subprocess.DEVNULL,
+            check=True,
         )
     try:
         yield
@@ -57,6 +60,7 @@ def with_pyproject_pep621_packages(_stash_away_project_toml, capsys, request):
             subprocess.run(
                 ["pip", "uninstall", "-y", *request.param],  # noqa: S603, S607
                 stdout=subprocess.DEVNULL,
+                check=True,
             )
             Path(repo_root / "pyproject.toml").rename(
                 deps_files / "pyproject.pep621.toml"
@@ -73,6 +77,7 @@ def with_requirements_txt_packages(_stash_away_project_toml, capsys, request):
         subprocess.run(
             ["pip", "install", *request.param],  # noqa: S603, S607
             stdout=subprocess.DEVNULL,
+            check=True,
         )
     try:
         yield
@@ -81,5 +86,6 @@ def with_requirements_txt_packages(_stash_away_project_toml, capsys, request):
             subprocess.run(
                 ["pip", "uninstall", "-y", *request.param],  # noqa: S603, S607
                 stdout=subprocess.DEVNULL,
+                check=True,
             )
             Path(repo_root / "requirements.txt").rename(deps_files / "requirements.txt")


### PR DESCRIPTION
## Why is the change needed?

This is a very short-term solution to just avoid having ruff break CI all the time, since each release brings new linting rules.

For example, dependabot PR break because ruff is not pinned/configured to run the same way on the code base: https://github.com/fredrikaverpil/creosote/pull/178

## What was done in this PR?

Hard-pin `ruff`. Let's rely on dependabot for updates of it instead.


## Are there any concerns, side-effects, additional notes?

The same problem applies to mypy and black, but they are not backwards-breaking compat as often. Wouldn't it have been nice if there was a native lockfile mechanism to pip/pyproject.toml ... 🤡 

## Checklist, when applicable

- [ ] Added test(s)
- [ ] Updated README.md
- [ ] Is this a backwards-compatibility breaking change?
- [ ] Resolves: #issue-number-here

