### PR TITLE
chore: remove renovate, rely on dependabot instead

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ]
-}


### PR DESCRIPTION
This just removes the ability to use renovate to update dependencies. Instead I'll rely on the already existing dependabot configuration.