### PR TITLE
chore: update dependabot interval to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     allow:
       - dependency-name: "*"
         dependency-type: all


### PR DESCRIPTION
## Why is the change needed?

Dependabot can be chatty about updates, especially for `ruff`, which is actively developed. This change just avoids noise for me.

## What was done in this PR?

Set dependabot's checking interval of dependency updates to `monthly`.

## Are there any concerns, side-effects, additional notes?

Nope.

## Checklist, when applicable

- [ ] Added test(s)
- [ ] Updated README.md
- [ ] Is this a backwards-compatibility breaking change?
- [ ] Resolves: #issue-number-here

