### PR TITLE
Fix bug which could give a false warning

### DIFF
--- a/src/creosote/parsers.py
+++ b/src/creosote/parsers.py
@@ -246,7 +246,11 @@ def get_excluded_deps_which_are_not_installed(
     if not excluded_deps:
         return dependency_names
 
-    for excluded_dep_name in excluded_deps:
+    excluded_deps_canonicalized = [
+        canonicalize_module_name(arg) for arg in excluded_deps
+    ]
+
+    for excluded_dep_name in excluded_deps_canonicalized:
         for venv in venvs:
             if excluded_dep_name not in get_installed_dependency_names(venv):
                 dependency_names.append(excluded_dep_name)
@@ -259,3 +263,7 @@ def get_excluded_deps_which_are_not_installed(
             f"{', '.join(dependency_names)}"
         )
     return dependency_names
+
+
+def canonicalize_module_name(module_name: str) -> str:
+    return module_name.replace("-", "_").replace(".", "_").strip()


### PR DESCRIPTION
## Why is the change needed?

When e.g. `creosote --exclude-dep dotty-dict` is entered, there is a false warning about "Excluded dependencies not found in virtual environment: dotty-dict".

```bash
$ creosote --exclude-dep dotty-dict             
Found dependencies in pyproject.toml: loguru, pip-requirements-parser, toml
Excluded dependencies not found in virtual environment: dotty-dict
No unused dependencies found! ✨
```

The reason for this is that the entered dependency name was not canonicalized as `dotty_dict`.

## What was done in this PR?

Canonicalize the dependency name when performing this check.

## Are there any concerns, side-effects, additional notes?

No.

## Checklist, when applicable

- [ ] Added test(s)
- [ ] Updated README.md
- [ ] Is this a backwards-compatibility breaking change?
- [ ] Resolves: #issue-number-here

