### PR TITLE
Support period sign in dependency name

### DIFF
--- a/src/creosote/resolvers.py
+++ b/src/creosote/resolvers.py
@@ -23,9 +23,9 @@ class DepsResolver:
         self.venvs: List[str] = venvs
 
         self.top_level_txt_pattern = re.compile(
-            r"\/([\w]*).[\d\.]*.dist-info\/top_level.txt"
+            r"\/([\w\.]*).[\d\.]*.dist-info\/top_level.txt"
         )
-        self.record_pattern = re.compile(r"\/([\w]*).[\d\.]*.dist-info\/RECORD")
+        self.record_pattern = re.compile(r"\/([\w\.]*).[\d\.]*.dist-info\/RECORD")
 
         self.top_level_filepaths: List[pathlib.Path] = []
         self.record_filepaths: List[pathlib.Path] = []
@@ -99,13 +99,16 @@ class DepsResolver:
         return False
 
     def map_dep_to_import_via_record_file(self, dep_info: DependencyInfo) -> bool:
-        dep_name = self.canonicalize_module_name(dep_info.name)
+        dep_name_canonicalized = self.canonicalize_module_name(dep_info.name)
 
         for record_filepath in self.record_filepaths:
             normalized_record_filepath = record_filepath.as_posix()
             matches = self.record_pattern.findall(normalized_record_filepath)
             for import_name_from_record in matches:
-                if import_name_from_record.lower() == dep_name.lower():
+                if (
+                    import_name_from_record.lower() == dep_name_canonicalized.lower()
+                    or import_name_from_record.lower() == dep_info.name.lower()
+                ):
                     with open(record_filepath, "r", encoding="utf-8") as infile:
                         lines = infile.readlines()
 


### PR DESCRIPTION
Fixes #205

To sum it up, ruamel.yaml has a period sign in its dependency name and in the folderpath and its RECORD file. This was not previously supported.

- Update regexp pattern for matching filepaths, so to support period signs.
- Looks for dependencies with raw name (e.g. ruamel.yaml) in `RECORD` files. Previously, the dependency name was "canonicalized" so that e.g. a period sign was converted into an underscore.
- Adds a test for ruamel.yaml.


Try it out:
```bash
# Creosote build from PR https://github.com/fredrikaverpil/creosote/issues/206
$ pipx install --suffix=@206 --force git+https://github.com/fredrikaverpil/creosote.git@refs/pull/206/head
$ creosote@206 --venv .venv ...
$ pipx uninstall creosote@206
```