### PR TITLE
Fix failing ci/linting

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,9 @@
 version: 2
-
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ path = "src/creosote/__about__.py"
 
 [project.optional-dependencies]
 # PEP-440
-lint = ["ruff"]
+lint = ["ruff>=0.4.7,<0.5"]
 types = ["mypy", "loguru-mypy", "types-toml"]
 test = ["pytest", "pytest-mock", "coverage"]
 dev = ["creosote[lint,types,test]"]
@@ -49,7 +49,9 @@ creosote = "creosote.cli:main"
 
 [tool.ruff]
 src = ["src", "tests"]
-line-length = 88 # black default
+line-length = 88       # black default
+
+[tool.ruff.lint]
 select = [
   "E", # pycodestyle (supersedes pep8)
   "W", # pycodestyle warnings
@@ -83,11 +85,10 @@ select = [
   "PLR", # pylint
   "PLW", # pylint
   "RUF", # ruff-specific rules
-
 ]
 ignore = []
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "tests/*" = [
   "S101", # assert used
   "S105", # hardcoded password

--- a/src/creosote/config.py
+++ b/src/creosote/config.py
@@ -20,7 +20,7 @@ class Config:
     the ``dest`` specified in ``add_argument``.
     """
 
-    format: Literal["default", "no-color", "porcelain"] = "default"  # noqa: A003
+    format: Literal["default", "no-color", "porcelain"] = "default"
     paths: List[str] = field(default_factory=lambda: ["src"])
     sections: List[str] = field(default_factory=lambda: ["project.dependencies"])
     exclude_deps: List[str] = field(default_factory=list)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,6 @@ Notes:
     https://docs.pytest.org/en/7.0.x/deprecations.html#pytest-plugins-in-non-top-level-conftest-files
 """
 
-
 import os
 from pathlib import Path
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -12,7 +12,6 @@ The general idea:
 
 """
 
-
 from typing import List
 
 import pytest


### PR DESCRIPTION
## Why is the change needed?

CI is failing due to ruff not being pinned.

## What was done in this PR?

- Update and pin ruff (will be updated by dependabot).
- Fix the pyproject.toml ruff warnings.
- Run `ruff format`.
- Run `ruff check --fix`.
- Set dependabot frequence to monthly (while I'm at it).

## Are there any concerns, side-effects, additional notes?

None.

## Checklist, when applicable

- [ ] Added test(s)
- [ ] Updated README.md
- [ ] Is this a backwards-compatibility breaking change?
- [ ] Resolves: #issue-number-here

