### PR TITLE
Add .ipynb files to parser file search

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,10 @@ This feature is intended for dependencies you must specify in your dependencies 
 $ creosote --exclude-dep pyodbc --exclude-dep pg8000
 ```
 
+### Can I run Creosote on Jupyter notebook (*.ipynb) files?
+
+Yes, any Jupyter notebook files will be temporarily converted to python files using [nbconvert](https://github.com/jupyter/nbconvert) and then Creosote will run on those.
+
 ### Can I run Creosote in a GitHub Action workflow?
 
 Yes, please see the `action` job example in [`.github/workflows/test.yml`](https://github.com/fredrikaverpil/creosote/blob/main/.github/workflows/test.yml).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ dynamic = ["version"]
 dependencies = [
   "dotty-dict>=1.3.1,<1.4",
   "loguru>=0.6.0,<0.8",
+  "nbconvert>=7.16.4,<8.0",
+  "nbformat>=5.10.4,<6.0",
   "pip-requirements-parser>=32.0.1,<33.1",
   "toml>=0.10.2,<0.11",
 ]

--- a/tests/notebook.ipynb
+++ b/tests/notebook.ipynb
@@ -1,0 +1,23 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import nbconvert\n",
+    "from nbformat import read\n",
+    "\n",
+    "print(\"hello\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/notebook.ipynb
+++ b/tests/notebook.ipynb
@@ -9,7 +9,9 @@
     "import nbconvert\n",
     "from nbformat import read\n",
     "\n",
-    "print(\"hello\")"
+    "# just making sure ruff won't complain about unused imports\n",
+    "print(nbconvert)\n",
+    "print(read)"
    ]
   }
  ],

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -30,7 +30,14 @@ def test_creosote_project_success(
     # arrange
 
     venv_path, site_packages_path = venv_manager.create_venv()
-    for dependency_name in ["dotty-dict", "loguru", "pip-requirements-parser", "toml"]:
+    for dependency_name in [
+        "dotty-dict",
+        "loguru",
+        "nbconvert",
+        "nbformat",
+        "pip-requirements-parser",
+        "toml",
+    ]:
         venv_manager.create_record(
             site_packages_path=site_packages_path,
             dependency_name=dependency_name,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -66,7 +66,7 @@ def test_creosote_project_success(
 
     assert actual_output == [
         "Found dependencies in pyproject.toml: "
-        "dotty-dict, loguru, pip-requirements-parser, toml",
+        "dotty-dict, loguru, nbconvert, nbformat, pip-requirements-parser, toml",
         "No unused dependencies found! ✨",
     ]
     assert exit_code == 0

--- a/tests/test_integration_notebook.py
+++ b/tests/test_integration_notebook.py
@@ -1,0 +1,77 @@
+from _pytest.capture import CaptureFixture
+
+from creosote import cli
+from tests.fixtures.integration import VenvManager
+
+
+def test_jupyter_ok(
+    venv_manager: VenvManager,
+    capsys: CaptureFixture,
+):
+    venv_path, site_packages_path = venv_manager.create_venv()
+
+    deps_filename = "pyproject.toml"
+    toml_section = "project.dependencies"
+    deps_file_contents = [
+        "[project]",
+        "dependencies = [",
+        '"nbconvert",',
+        '"nbformat",',
+        "]",
+    ]
+
+    installed_dependencies = [
+        "nbconvert",
+        "nbformat",
+    ]
+
+    for dependency_name in installed_dependencies:
+        venv_manager.create_record(
+            site_packages_path=site_packages_path,
+            dependency_name=dependency_name,
+            contents=[
+                f"{dependency_name}/__init__.py,sha256=4skFj_sdo33SWqTefV1JBAvZiT4MY_pB5yaRL5DMNVs,240"
+            ],
+        )
+
+    deps_filepath = venv_manager.create_deps_file(
+        relative_filepath=deps_filename,
+        contents=deps_file_contents,
+    )
+
+    with open("tests/notebook.ipynb", "r") as notebook:
+        contents = notebook.readlines()
+
+    source_file = venv_manager.create_source_file(
+        relative_filepath="src/foo.ipynb",
+        contents=contents,
+    )
+
+    args = [
+        "--venv",
+        str(venv_path),
+        "--path",
+        str(source_file),
+        "--deps-file",
+        str(deps_filepath),
+        "--section",
+        toml_section,
+        "--format",
+        "no-color",
+    ]
+
+    if not toml_section:
+        # this is the case for requirements.txt
+        args.remove("--section")
+        args.remove(toml_section)
+
+    # act
+    exit_code = cli.main(args)
+    actual_output = capsys.readouterr().err.splitlines()
+
+    # assert
+    assert actual_output == [
+        f"Found dependencies in {deps_filepath}: nbconvert, nbformat",
+        "No unused dependencies found! ✨",
+    ]
+    assert exit_code == 0


### PR DESCRIPTION
## Why is the change needed?
This PR adds support for parsing and recognizing dependencies in Jupyter notebooks, which can be helpful in notebook-heavy workflows where some dependencies are only used in notebooks but shouldn't be counted as unused.

## What was done in this PR?
- Adds two dependencies needed for converting .ipynb files to .py
- Adds .ipynb files to the list of files to be parsed for module names
- Adds logic to `get_module_info_from_python_file()` such that if the current file is a .ipynb, use `nbconvert` to convert the notebook to a temporary file, then parse that file for dependencies as usual.

## Are there any concerns, side-effects, additional notes?
A couple small flags:
- There's a more elegant way of handling the temporary file creation + deletion using tempfile's `delete_on_close` parameter, but this is only supported in Python 3.12+ so I left it out.  Happy to make other changes to that logic if you have any thoughts on it.
- I had some trouble running test_integration.py locally, but I believe that would be the only place to add testing for this PR.  If the general structure of these changes looks good, I'll add that integration test.
- One other thing to consider is that .ipynb support could be a configured option in pyproject.toml.  Personally I can't really think of a good reason why the support should be disabled (you either have notebooks in your repo and want their imports to be recognized, or you don't have notebooks and it's not an issue), but throwing it out there anyway.  I didn't implement this config option and I'll hold off on updating README.md unless you don't have a preference either way.

## Checklist, when applicable

- [ ] Added test(s)
- [ ] Updated README.md
- [ ] Is this a backwards-compatibility breaking change?
- [x] Resolves: #216 

