### PR TITLE
fix: compare using canonicalization

### DIFF
--- a/src/creosote/resolvers.py
+++ b/src/creosote/resolvers.py
@@ -79,13 +79,15 @@ class DepsResolver:
         Return True if import name was found in the top_level.txt,
         otherwise return False.
         """
-        dep_name = self.canonicalize_module_name(dep_info.name)
 
         for top_level_filepath in self.top_level_filepaths:
             normalized_top_level_filepath = top_level_filepath.as_posix()
             matches = self.top_level_txt_pattern.findall(normalized_top_level_filepath)
-            for import_name_from_top_level in matches:
-                if import_name_from_top_level.lower() == dep_name.lower():
+            for name_from_top_level in matches:
+                if (
+                    self.canonicalize_module_name(name_from_top_level).lower()
+                    == self.canonicalize_module_name(dep_info.name).lower()
+                ):
                     with open(
                         top_level_filepath, "r", encoding="utf-8", errors="replace"
                     ) as infile:
@@ -101,15 +103,13 @@ class DepsResolver:
         return False
 
     def map_dep_to_import_via_record_file(self, dep_info: DependencyInfo) -> bool:
-        dep_name_canonicalized = self.canonicalize_module_name(dep_info.name)
-
         for record_filepath in self.record_filepaths:
             normalized_record_filepath = record_filepath.as_posix()
             matches = self.record_pattern.findall(normalized_record_filepath)
-            for import_name_from_record in matches:
+            for name_from_record in matches:
                 if (
-                    import_name_from_record.lower() == dep_name_canonicalized.lower()
-                    or import_name_from_record.lower() == dep_info.name.lower()
+                    self.canonicalize_module_name(name_from_record).lower()
+                    == self.canonicalize_module_name(dep_info.name).lower()
                 ):
                     with open(
                         record_filepath, "r", encoding="utf-8", errors="replace"

--- a/src/creosote/resolvers.py
+++ b/src/creosote/resolvers.py
@@ -99,7 +99,7 @@ class DepsResolver:
                         f"via top_level.txt: {import_names} ⭐️"
                     )
                     return True
-        logger.debug(f"[{dep_info.name}] did not find top_level.txt in venv")
+        logger.debug(f"[{dep_info.name}] did not find dep in a top_level.txt file")
         return False
 
     def map_dep_to_import_via_record_file(self, dep_info: DependencyInfo) -> bool:
@@ -133,7 +133,7 @@ class DepsResolver:
                             )
                             return True
 
-        logger.debug(f"[{dep_info.name}] did not find RECORD in venv")
+        logger.debug(f"[{dep_info.name}] did not find dep in a RECORD file")
         return False
 
     def map_dep_to_canonical_name(self, dep_info: DependencyInfo) -> str:


### PR DESCRIPTION
## Why is the change needed?

Bug described and reproduced in #205.


## What was done in this PR?

The import name found in the top_level.txt or RECORD files was not accurately compared against the dependency name. The latter had been canonicalized whereas the former had not.

## Are there any concerns, side-effects, additional notes?

@sanmai-NL thanks for persistently poking me about this. I believe it's finally fixed. You can try it out like so:

```bash
$ pipx install --suffix=@222 --force git+https://github.com/fredrikaverpil/creosote.git@refs/pull/222/head
$ creosote@222 --venv .venv ...
$ pipx uninstall creosote@222
```


## Checklist, when applicable

- [ ] Added test(s)
- [ ] Updated README.md
- [ ] Is this a backwards-compatibility breaking change?
- [x] Resolves: #205

