### PR TITLE
feat(parser): add PEP-735 support for dependency-groups

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,7 @@ jobs:
           source .venv/bin/activate
           echo "VIRTUAL_ENV: $VIRTUAL_ENV"
           pip install --upgrade .
-          creosote --venv .venv
+          creosote --venv .venv --exclude-dep tomli
 
       - name: run creosote (windows)
         if: ${{ matrix.os == 'windows-latest' }}
@@ -88,4 +88,4 @@ jobs:
           .venv/Scripts/Activate.ps1
           Write-Host "VIRTUAL_ENV: $env:VIRTUAL_ENV"
           pip install --upgrade .
-          creosote --venv .venv
+          creosote --venv .venv --exclude-dep tomli

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ depending on your objectives.
 | Legacy Setuptools (`setup.py`)                                                                                              |    ❌     |                     |                                                                                                                     |
 | [PEP-508](https://peps.python.org/pep-0508/) (`requirements.txt`, [pip-tools](https://pip-tools.readthedocs.io/en/latest/)) |    ✅     | `*.[txt\|in]`       | N/A                                                                                                                 |
 | [PEP-621](https://peps.python.org/pep-0621/)                                                                                |    ✅     | `pyproject.toml`    | `project.dependencies`,<br>`project.optional-dependencies.<GROUP>`                                                  |
+| [PEP-735](https://peps.python.org/pep-0735/)                                                                                |    ✅     | `pyproject.toml`    | `dependency-groups`                                                                                                 |
 
 #### 📔 Notes on [PEP-508](https://peps.python.org/pep-0508) (`requirements.txt`)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "nbconvert>=7.16.4,<8.0",
   "nbformat>=5.10.4,<6.0",
   "pip-requirements-parser>=32.0.1,<33.1",
-  "tomli>=2.1.0,<3.0.0",
+  "tomli>=2.1.0,<3.0.0 ; python_version < '3.11'",
 ]
 
 [tool.hatch.version]
@@ -39,7 +39,7 @@ path = "src/creosote/__about__.py"
 [project.optional-dependencies]
 # PEP-440
 lint = ["ruff>=0.5.0,<0.8"]
-types = ["mypy", "loguru-mypy", "types-toml"]
+types = ["mypy", "loguru-mypy"]
 test = ["pytest", "pytest-mock", "coverage"]
 dev = ["creosote[lint,types,test]"]
 
@@ -101,7 +101,7 @@ ignore = []
 python_version = "3.8"
 
 [[tool.mypy.overrides]]
-module = ["dotty_dict.*", "pip_requirements_parser.*"]
+module = ["dotty_dict.*", "pip_requirements_parser.*", "tomli.*"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "nbconvert>=7.16.4,<8.0",
   "nbformat>=5.10.4,<6.0",
   "pip-requirements-parser>=32.0.1,<33.1",
-  "toml>=0.10.2,<0.11",
+  "tomli>=2.1.0,<3.0.0",
 ]
 
 [tool.hatch.version]

--- a/src/creosote/config.py
+++ b/src/creosote/config.py
@@ -7,7 +7,11 @@ from enum import Enum
 from pathlib import Path
 from typing import List, Literal
 
-import tomli
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
 from loguru import logger
 
 from creosote.__about__ import __version__
@@ -183,7 +187,7 @@ def load_defaults(src: str = "pyproject.toml") -> Config:
 
     try:
         with open(src, "rb") as f:
-            project_config = tomli.load(f)
+            project_config = tomllib.load(f)
     except FileNotFoundError:
         project_config = {}
     creosote_config = project_config.get("tool", {}).get("creosote", {})

--- a/src/creosote/config.py
+++ b/src/creosote/config.py
@@ -7,7 +7,7 @@ from enum import Enum
 from pathlib import Path
 from typing import List, Literal
 
-import toml
+import tomli
 from loguru import logger
 
 from creosote.__about__ import __version__
@@ -182,8 +182,8 @@ def load_defaults(src: str = "pyproject.toml") -> Config:
     """
 
     try:
-        with open(src, "r", encoding="utf-8", errors="replace") as f:
-            project_config = toml.loads(f.read())
+        with open(src, "rb") as f:
+            project_config = tomli.load(f)
     except FileNotFoundError:
         project_config = {}
     creosote_config = project_config.get("tool", {}).get("creosote", {})

--- a/src/creosote/parsers.py
+++ b/src/creosote/parsers.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any, Dict, Generator, List, Union, cast
 
 import nbformat
-import toml
+import tomli
 from dotty_dict import Dotty, dotty
 from loguru import logger
 from nbconvert import PythonExporter
@@ -129,8 +129,8 @@ class DependencyReader:
 
     def read_toml(self, deps_file: str, sections: List[str]) -> List[str]:
         """Read dependency names from toml spec file."""
-        with open(deps_file, "r", encoding="utf-8", errors="replace") as infile:
-            contents = toml.loads(infile.read())
+        with open(deps_file, "rb") as infile:
+            contents = tomli.load(infile)
 
         dotty_contents: Dotty = dotty(contents)
         dep_names = []

--- a/src/creosote/parsers.py
+++ b/src/creosote/parsers.py
@@ -1,11 +1,17 @@
 import ast
 import re
+import sys
 import tempfile
 from pathlib import Path
 from typing import Any, Dict, Generator, List, Union, cast
 
 import nbformat
-import tomli
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
 from dotty_dict import Dotty, dotty
 from loguru import logger
 from nbconvert import PythonExporter
@@ -130,7 +136,7 @@ class DependencyReader:
     def read_toml(self, deps_file: str, sections: List[str]) -> List[str]:
         """Read dependency names from toml spec file."""
         with open(deps_file, "rb") as infile:
-            contents = tomli.load(infile)
+            contents = tomllib.load(infile)
 
         dotty_contents: Dotty = dotty(contents)
         dep_names = []

--- a/src/creosote/parsers.py
+++ b/src/creosote/parsers.py
@@ -89,6 +89,35 @@ class DependencyReader:
 
         return section_deps
 
+    def get_deps_from_pep735_toml(
+        self, section_contents: Union[List[str], Dict[str, List[str]]]
+    ) -> List[str]:
+        """Get dependency names from toml file using the PEP735 spec.
+
+        The dependency strings are expected to follow PEP508.
+        """
+
+        dep_strings = []
+        if isinstance(section_contents, dict):
+            for _, dep_string_list in section_contents.items():
+                for dep_string in dep_string_list:
+                    if type(dep_string) != str:
+                        logger.debug(f"Skipping non-string entry: {dep_string}")
+                        continue
+                    dep_strings.append(dep_string)
+        else:
+            raise TypeError("Unexpected dependency format, list expected.")
+
+        section_deps = []
+        for dep_string in dep_strings:
+            parsed_dep = self.parse_dep_string(dep_string)
+            if parsed_dep:
+                section_deps.append(parsed_dep)
+            else:
+                logger.warning(f"Could not parse dependency string: {dep_string}")
+
+        return section_deps
+
     def get_deps_from_toml_section_keys(
         self,
         section_contents: Dict[str, Any],
@@ -121,6 +150,9 @@ class DependencyReader:
             elif section.startswith("tool.pdm"):
                 logger.debug(f"Detected PDM toml section in {deps_file}")
                 section_dep_names = self.get_deps_from_pep621_toml(section_contents)
+            elif section.startswith("dependency-groups"):
+                logger.debug(f"Detected PEP-735 toml section in {deps_file}")
+                section_dep_names = self.get_deps_from_pep735_toml(section_contents)
             elif section.startswith("tool.poetry"):
                 logger.debug(f"Detected Poetry toml section in {deps_file}")
                 section_dep_names = self.get_deps_from_toml_section_keys(

--- a/tests/deps_files/pyproject.pep735.toml
+++ b/tests/deps_files/pyproject.pep735.toml
@@ -1,0 +1,5 @@
+[dependency-groups]
+test = ["pytest", "coverage"]
+docs = ["sphinx", "sphinx-rtd-theme"]
+typing = ["mypy", "types-requests"]
+typing-test = [{include-group = "typing"}, {include-group = "test"}, "useful-types"]

--- a/tests/test_dependency_reader.py
+++ b/tests/test_dependency_reader.py
@@ -41,6 +41,33 @@ def test_read_toml_pep621(sections: List[str], expected_dependencies: List[str])
     ["sections", "expected_dependencies"],
     [
         (
+            ["dependency-groups"],
+            [
+                "coverage",
+                "mypy",
+                "pytest",
+                "sphinx",
+                "sphinx-rtd-theme",
+                "types-requests",
+                # "useful-types",  # NOTE: not supported by toml yet
+            ],
+        ),
+    ],
+)
+def test_read_toml_pep735(sections: List[str], expected_dependencies: List[str]):
+    reader = DependencyReader(
+        deps_file="tests/deps_files/pyproject.pep735.toml",
+        sections=sections,
+        exclude_deps=[],
+    )
+    dependencies = reader.read()
+    assert dependencies == expected_dependencies
+
+
+@pytest.mark.parametrize(
+    ["sections", "expected_dependencies"],
+    [
+        (
             ["tool.poetry.dependencies"],
             ["dotty-dict", "loguru", "toml"],
         ),

--- a/tests/test_dependency_reader.py
+++ b/tests/test_dependency_reader.py
@@ -49,7 +49,7 @@ def test_read_toml_pep621(sections: List[str], expected_dependencies: List[str])
                 "sphinx",
                 "sphinx-rtd-theme",
                 "types-requests",
-                # "useful-types",  # NOTE: not supported by toml yet
+                "useful-types",
             ],
         ),
     ],

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -36,7 +36,7 @@ def test_creosote_project_success(
         "nbconvert",
         "nbformat",
         "pip-requirements-parser",
-        "toml",
+        "tomli",
     ]:
         venv_manager.create_record(
             site_packages_path=site_packages_path,
@@ -66,7 +66,7 @@ def test_creosote_project_success(
 
     assert actual_output == [
         "Found dependencies in pyproject.toml: "
-        "dotty-dict, loguru, nbconvert, nbformat, pip-requirements-parser, toml",
+        "dotty-dict, loguru, nbconvert, nbformat, pip-requirements-parser, tomli",
         "No unused dependencies found! ✨",
     ]
     assert exit_code == 0

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -53,6 +53,8 @@ def test_creosote_project_success(
         "src",  # use this project's "src" folder
         "--deps-file",
         "pyproject.toml",  # use this project's own pyproject.toml
+        "--exclude-dep",
+        "tomli",  # NOTE: special handling for python < 3.11
         "--format",
         "no-color",
     ]
@@ -66,7 +68,7 @@ def test_creosote_project_success(
 
     assert actual_output == [
         "Found dependencies in pyproject.toml: "
-        "dotty-dict, loguru, nbconvert, nbformat, pip-requirements-parser, tomli",
+        "dotty-dict, loguru, nbconvert, nbformat, pip-requirements-parser",
         "No unused dependencies found! ✨",
     ]
     assert exit_code == 0


### PR DESCRIPTION
fixes #221

⚠️ it might be good to bump Creosote to 4.0 following this change (replacing the toml library) 🤔 and if so, it would be good to take advantage of this so also to move from `v1.2.3` -> `1.2.3` release tags (for release-please).