### PR TITLE
ci: use uv instead of pip

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,11 @@
 version: 2
+enable-beta-ecosystems: true
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "monthly"


### PR DESCRIPTION
## Why is the change needed?

Dependabot can now handle `uv`.

## What was done in this PR?

- Add beta directive.
- Replace `pip` eco system with `uv`.

## Are there any concerns, side-effects, additional notes?

- See more: https://github.com/dependabot/dependabot-core/issues/10478#issuecomment-2691330949

## Checklist, when applicable

- [ ] Added test(s)
- [ ] Updated README.md
- [ ] Is this a backwards-compatibility breaking change?
- [ ] Resolves: #issue-number-here

