### PR TITLE
ci(workflows): sync with fredrikaverpil/github

### DIFF
--- a/.github/workflows/sync-dependabot.yml
+++ b/.github/workflows/sync-dependabot.yml
@@ -1,0 +1,11 @@
+name: dependabot
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 8 * * 1" # Monday at 8am
+
+jobs:
+  title:
+    uses: fredrikaverpil/github/.github/workflows/gen-dependabot.yml@main
+    secrets: inherit


### PR DESCRIPTION
This PR syncs the GitHub repo with CI workflows from the [fredrikaverpil/github](https://github.com/fredrikaverpil/github) repository.