### PR TITLE
fix: version suffix not supported by regexp

### DIFF
--- a/src/creosote/resolvers.py
+++ b/src/creosote/resolvers.py
@@ -7,6 +7,10 @@ from loguru import logger
 
 from creosote.models import DependencyInfo, ImportInfo
 
+# Define the PEP 440 compliant version pattern (non-capturing)
+# Based on https://packaging.python.org/en/latest/specifications/version-specifiers/#appendix-parsing-version-strings-with-regular-expressions
+VERSION_PATTERN_STR = r"v?(?:(?:[0-9]+!)?(?:[0-9]+(?:\.[0-9]+)*)(?:(?:[-_\.]?(?:a|b|c|rc|alpha|beta|pre|preview)[-_\.]?(?:[0-9]+)?))?(?:(?:-(?:[0-9]+))|(?:[-_\.]?(?:post|rev|r)[-_\.]?(?:[0-9]+)?))?(?:(?:[-_\.]?(?:dev)[-_\.]?(?:[0-9]+)?))?)(?:\+[a-z0-9]+(?:[-_\.][a-z0-9]+)*)?"
+
 
 class DepsResolver:
     def __init__(
@@ -21,11 +25,16 @@ class DepsResolver:
         ]
         self.venvs: list[str] = venvs
 
+        # Capture package names before PEP 440 compliant versions
+        # Package name allows letters, numbers, underscore, dot, hyphen
+        # Version part uses the non-capturing pattern defined above
+        # Compiled with re.IGNORECASE for version specifier case-insensitivity (e.g., rc vs RC)
         self.top_level_txt_pattern: re.Pattern[str] = re.compile(
-            r"\/([\w\.]*).[\d\.]*.dist-info\/top_level.txt"
+            rf"\/([\w\.-]+)-(?:{VERSION_PATTERN_STR})\.dist-info\/top_level\.txt",
+            re.IGNORECASE,
         )
         self.record_pattern: re.Pattern[str] = re.compile(
-            r"\/([\w\.]*).[\d\.]*.dist-info\/RECORD"
+            rf"\/([\w\.-]+)-(?:{VERSION_PATTERN_STR})\.dist-info\/RECORD", re.IGNORECASE
         )
 
         self.top_level_filepaths: list[pathlib.Path] = []

--- a/tests/fixtures/integration.py
+++ b/tests/fixtures/integration.py
@@ -35,15 +35,12 @@ class VenvManager:
         site_packages_path: Path,
         dependency_name: str,
         contents: list[str],
+        version: str = "1.2.3",  # Add version parameter
     ) -> Path:
-        """Simulate an installed dependency and its RECORD file.
-
-        This is the most reliable way for creosote to find a dependency
-        and correlate its import naming against the actual dependency
-        name.
-        """
-        dist_info_path = site_packages_path / f"{dependency_name}-1.2.3.dist-info"
-        dist_info_path.mkdir(parents=True)
+        """Simulate an installed dependency and its RECORD file."""
+        # Use the provided version in the directory name
+        dist_info_path = site_packages_path / f"{dependency_name}-{version}.dist-info"
+        dist_info_path.mkdir(parents=True, exist_ok=True)
         record_path = dist_info_path / "RECORD"
         _ = record_path.write_text("\n".join(contents))
         return record_path
@@ -53,15 +50,12 @@ class VenvManager:
         site_packages_path: Path,
         dependency_name: str,
         contents: list[str],
+        version: str = "1.2.3",  # Add version parameter
     ) -> Path:
-        """Simulate an installed dependency and its top_level.txt file.
-
-        This is a less reliable way for creosote to find a dependency
-        and correlate its import naming against the actual dependency
-        name.
-        """
-        dist_info_path = site_packages_path / f"{dependency_name}-1.2.3.dist-info"
-        dist_info_path.mkdir(parents=True)
+        """Simulate an installed dependency and its top_level.txt file."""
+        # Use the provided version in the directory name
+        dist_info_path = site_packages_path / f"{dependency_name}-{version}.dist-info"
+        dist_info_path.mkdir(parents=True, exist_ok=True)
         top_level_txt_path = dist_info_path / "top_level.txt"
         _ = top_level_txt_path.write_text("\n".join(contents))
         return top_level_txt_path


### PR DESCRIPTION
## Why is the change needed?

Issue found in #274 where version suffix `rc1` is not detected properly by internal regular expressions (this is a very good catch).

## What was done in this PR?

- Update regexp with ["official" regexp](https://packaging.python.org/en/latest/specifications/version-specifiers/#appendix-parsing-version-strings-with-regular-expressions)

## Are there any concerns, side-effects, additional notes?

I don't think so.

## Checklist, when applicable

- [x] Added test(s)
- [ ] Updated README.md
- [ ] Is this a backwards-compatibility breaking change?
- [x] Resolves: #274

