### PR TITLE
ci(workflows): sync with fredrikaverpil/github

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
       - name: run sync action
         uses: fredrikaverpil/github/.github/actions/sync@main


### PR DESCRIPTION
This PR syncs the GitHub repo with CI workflows from the [fredrikaverpil/github](https://github.com/fredrikaverpil/github) repository.