### PR TITLE
fix(django): improve resolution, variable mutation tracking

### DIFF
--- a/src/creosote/parsers.py
+++ b/src/creosote/parsers.py
@@ -484,6 +484,7 @@ class DjangoSettingsVisitor(ast.NodeVisitor):
     def __init__(self) -> None:
         self.variable_assignments: dict[str, list[str]] = {}
         self.target_nodes: list[ast.expr] = []
+        self.variable_mutations: list[tuple[str, ast.expr]] = []
 
     def _is_target_setting(self, name: str) -> bool:
         """Check if a variable name is a Django setting we're tracking."""
@@ -512,29 +513,50 @@ class DjangoSettingsVisitor(ast.NodeVisitor):
 
     @override
     def visit_AugAssign(self, node: ast.AugAssign) -> None:
-        """Collect augmented assignments (+=) to INSTALLED_APPS/MIDDLEWARE."""
-        if isinstance(node.target, ast.Name) and self._is_target_setting(
-            node.target.id
-        ):
-            self.target_nodes.append(node.value)
+        """Collect augmented assignments (+=) to target settings and variables."""
+        if isinstance(node.target, ast.Name):
+            if self._is_target_setting(node.target.id):
+                self.target_nodes.append(node.value)
+            else:
+                # Track mutations to regular variables for later resolution
+                self.variable_mutations.append((node.target.id, node.value))
         self.generic_visit(node)
 
     @override
     def visit_Expr(self, node: ast.Expr) -> None:
-        """Collect .append/.extend calls to INSTALLED_APPS/MIDDLEWARE."""
+        """Collect .append/.extend calls to INSTALLED_APPS/MIDDLEWARE and variables."""
         if isinstance(node.value, ast.Call):
             call = node.value
             if (
                 isinstance(call.func, ast.Attribute)
                 and isinstance(call.func.value, ast.Name)
-                and self._is_target_setting(call.func.value.id)
                 and call.func.attr in ("append", "extend")
             ):
-                self.target_nodes.extend(call.args)
+                if self._is_target_setting(call.func.value.id):
+                    self.target_nodes.extend(call.args)
+                else:
+                    # Track mutations to regular variables for later resolution
+                    for arg in call.args:
+                        self.variable_mutations.append((call.func.value.id, arg))
         self.generic_visit(node)
 
     def resolve_modules(self) -> set[str]:
-        """Resolve all collected INSTALLED_APPS/MIDDLEWARE references."""
+        """Resolve all collected INSTALLED_APPS/MIDDLEWARE references.
+
+        Applies mutations (augmented assignments and method calls) to variables
+        before resolving target nodes, enabling proper handling of patterns like:
+            APPS = ['a']
+            APPS += ['b']
+            INSTALLED_APPS = APPS
+        """
+        # Apply mutations to variable assignments
+        for var_name, mutation_node in self.variable_mutations:
+            if var_name in self.variable_assignments:
+                additional = _resolve_expression(
+                    mutation_node, self.variable_assignments
+                )
+                self.variable_assignments[var_name].extend(additional)
+
         return {
             module
             for node in self.target_nodes

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -168,6 +168,23 @@ from creosote.parsers import get_modules_from_django_settings
             ["django", "extra"],  # Two-pass resolution handles forward references
             id="forward_reference_with_concatenation",
         ),
+        # Test augmented assignment with variable reference
+        pytest.param(
+            ("APPS = ['a']\nAPPS += ['b']\nINSTALLED_APPS = APPS"),
+            ["a", "b"],
+            id="augmented_assignment_then_reference",
+        ),
+        # Test method calls with variable reference
+        pytest.param(
+            ("APPS = ['a']\nAPPS.append('b')\nINSTALLED_APPS = APPS"),
+            ["a", "b"],
+            id="append_method_then_reference",
+        ),
+        pytest.param(
+            ("APPS = ['a']\nAPPS.extend(['b'])\nINSTALLED_APPS = APPS"),
+            ["a", "b"],
+            id="extend_method_then_reference",
+        ),
     ],
 )
 def test_get_modules_from_django_settings(


### PR DESCRIPTION
## Why?

- PR #339 was merged with a limitation where variable assignments and forward references in `INSTALLED_APPS` and `MIDDLEWARE` were not handled.

## What?

### Forward Reference Resolution
- **Single-pass collection + resolution**: Implemented a `DjangoSettingsVisitor` that collects all variable assignments in one pass, then resolves `INSTALLED_APPS`/`MIDDLEWARE` references after traversal
- **Forward reference support**: The approach allows `INSTALLED_APPS` to reference variables defined later in the file (e.g., `INSTALLED_APPS = PREREQ_APPS` where `PREREQ_APPS = ['django']` appears after)
- **Expression resolution**: Handles list/tuple concatenation (e.g., `APPS + ['new_app']`), augmented assignment (`+=`), and `.append()`/`.extend()` calls

### Variable Mutation Tracking
- **Mutation tracking**: Tracks augmented assignments (`+=`) and method calls (`.append()`, `.extend()`) on variables, not just on `INSTALLED_APPS`/`MIDDLEWARE` directly
- **Correct resolution of mutated variables**: Properly resolves patterns like:
  ```python
  APPS = ['a']
  APPS += ['b']
  INSTALLED_APPS = APPS  # Now correctly resolves to ['a', 'b']
  ```
