### PR TITLE
fix: handle single PEP 735 dependency group in section path

### DIFF
--- a/src/creosote/parsers.py
+++ b/src/creosote/parsers.py
@@ -29,7 +29,8 @@ PEP621Type2 = dict[GroupName, list[PackageName]]
 PEP621Types = PEP621Type1 | PEP621Type2
 PEP735Type1 = dict[GroupName, list[PackageName]]
 PEP735Type2 = dict[GroupName, list[dict[str, PackageName] | str]]
-PEP735Types = PEP735Type1 | PEP735Type2
+PEP735Type3 = list[dict[str, PackageName] | str]
+PEP735Types = PEP735Type1 | PEP735Type2 | PEP735Type3
 PoetryType1 = dict[PackageName, str]
 PoetryType2 = dict[PackageName, dict[str, str]]
 PoetryType3 = dict[PackageName, str | dict[str, str]]
@@ -44,6 +45,7 @@ AllSupportedTypes = (
     | PEP621Type2
     | PEP735Type1
     | PEP735Type2
+    | PEP735Type3
     | PoetryType1
     | PoetryType2
     | PoetryType3
@@ -178,7 +180,13 @@ class DependencyReader:
         """
 
         dep_strings: list[str] = []
-        if is_dict_of_lists(section_contents):
+        if is_list_type(section_contents):
+            for item in section_contents:
+                if type(item) is not str:
+                    logger.debug(f"Skipping non-string entry: {item}")
+                    continue
+                dep_strings.append(item)
+        elif is_dict_of_lists(section_contents):
             for _, dep_string_list in section_contents.items():
                 for dep_string in dep_string_list:
                     if type(dep_string) is not str:

--- a/tests/test_dependency_reader.py
+++ b/tests/test_dependency_reader.py
@@ -52,6 +52,14 @@ def test_read_toml_pep621(
                 "useful-types",
             ],
         ),
+        (
+            ["dependency-groups.test"],
+            ["coverage", "pytest"],
+        ),
+        (
+            ["dependency-groups.typing-test"],
+            ["useful-types"],
+        ),
     ],
 )
 def test_read_toml_pep735(


### PR DESCRIPTION
## Why is the change needed?

When specifying a specific dependency group (e.g. dependency-groups.test), dotty resolves the section to a plain list rather than a dict[group → list]. get_deps_from_pep735_toml only handled the dict shape and raised TypeError on the list case. 

## What was done in this PR?
  - Add PEP735Type3 (plain list variant) to PEP735Types     
  - Add is_list_type branch in get_deps_from_pep735_toml before the existing is_dict_of_lists check, skipping non-string entries (e.g. {include-group: ...} dicts)
  - Add test cases for dependency-groups.test and dependency-groups.typing-test

## Are there any concerns, side-effects, additional notes?


## Checklist, when applicable

- [x] Added test(s)
- [ ] Updated README.md
- [ ] Is this a backwards-compatibility breaking change?
- [x] Resolves: #369
